### PR TITLE
Allow preview even if no Dockefile inline and location are not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- Allow unknows value in the `dockerfile.inline` field during the preview. (https://github.com/pulumi/pulumi-docker-build/pull/89)
 - Fixed the default value for `ACTIONS_CACHE_URL` when using GitHub action caching. (https://github.com/pulumi/pulumi-docker-build/pull/80)
 - Fixed Java SDK publishing. (https://github.com/pulumi/pulumi-docker-build/pull/89)
 - Fixed a panic that could occur when `context` was omitted. (https://github.com/pulumi/pulumi-docker-build/pull/83)

--- a/provider/internal/context.go
+++ b/provider/internal/context.go
@@ -127,9 +127,12 @@ func (bc *BuildContext) validate(preview bool, d *Dockerfile) (*Dockerfile, *Con
 		return d, c, newCheckFailure(err, "context.location")
 	}
 
-	if d.Location == "" && d.Inline == "" {
+	if d.Location == "" && d.Inline == "" && !preview {
 		// If a Dockerfile wasn't provided and our context is on-disk, then
-		// set our Dockerfile to a default of <PATH>/Dockerfile.
+		// set our Dockerfile to a default of <PATH>/Dockerfile. However, if
+		// we're in preview mode, we don't want to do this because we don't
+		// know if the inline Dockerfile parameter contains unknowns or if
+		// we will use the default Dockerfile.
 		d.Location = filepath.Join(c.Location, "Dockerfile")
 	}
 


### PR DESCRIPTION
When using the `dockerfile.inline` parameter, we use a "future" reference to something that has not yet been computed during the preview stage.

In this case, `dockefile.location` and `dockerfile.infile` may be empty but will be available during the processing stage. Fixes #96.