### PR TITLE
Fix Go SDK publishing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -585,8 +585,8 @@ jobs:
       with:
         repository: ${{ github.repository }}
         base-ref: ${{ github.sha }}
-        source: sdk
-        path: sdk
+        source: sdk/go/dockerbuild
+        path: sdk/go/dockerbuild
         version: ${{ steps.version.outputs.version }}
         additive: false
         files: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -585,8 +585,8 @@ jobs:
       with:
         repository: ${{ github.repository }}
         base-ref: ${{ github.sha }}
-        source: sdk
-        path: sdk
+        source: sdk/go/dockerbuild
+        path: sdk/go/dockerbuild
         version: ${{ steps.version.outputs.version }}
         additive: false
         files: |-


### PR DESCRIPTION
This provider's SDK module is rooted in `sdk/go/dockerbuild` instead than `sdk` as other providers are set up.

Fixes https://github.com/pulumi/pulumi-docker-build/issues/93