### PR TITLE
Re-enable grouping for dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,17 @@ updates:
       pulumi:
         patterns:
           - "github.com/pulumi/*"
+      docker:
+        patterns:
+          - "github.com/docker/*"
+          - "github.com/moby/*"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      other:
+        patterns:
+          - "*"
     labels:
       - dependencies
       - impact/no-changelog-required


### PR DESCRIPTION
Context: I'm using this repo as a testing ground for using Dependabot to handle more of our dependency management.

We have grouped security updates enabled by default at the org level, however when a repo defines its own `dependabot.yml` it will override the org's defaults. We don't currently define any grouping for security updates, hence why we have so many outstanding dependabot PRs.

This adds 3 new groups:
* A security group, to re-enable grouped security updates.
* A docker group, to bump core Docker dependencies like buildx, buildkit, etc.
* An "other" group as a catch-all for everything else. AFAICT there's no way to have Dependabot _only_ bump versions for Pulumi & Docker dependencies, so just dump everything else in here.

The existing pulumi group stopped receiving updates for some reason but [seems to be working](https://github.com/pulumi/pulumi-docker-build/pull/111) again after I re-opened one of the closed PRs.
