### PR TITLE
Use 'buildkit' as default scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Multiple exports are now allowed if the build daemon is detected to have
   version 0.13 of Buildkit or newer. (<https://github.com/pulumi/pulumi-docker-build/issues/21>)
+-  Use 'buildkit' as default scope (<https://github.com/pulumi/pulumi-docker-build/pull/516>)
 
 ### Changed
 

--- a/provider/cmd/pulumi-resource-docker-build/schema.json
+++ b/provider/cmd/pulumi-resource-docker-build/schema.json
@@ -159,12 +159,7 @@
         "scope": {
           "type": "string",
           "description": "The scope to use for cache keys. Defaults to `buildkit`.\n\nThis should be set if building and caching multiple images in one\nworkflow, otherwise caches will overwrite each other.",
-          "default": "",
-          "defaultInfo": {
-            "environment": [
-              "buildkit"
-            ]
-          }
+          "default": "buildkit"
         },
         "token": {
           "type": "string",
@@ -389,12 +384,7 @@
         "scope": {
           "type": "string",
           "description": "The scope to use for cache keys. Defaults to `buildkit`.\n\nThis should be set if building and caching multiple images in one\nworkflow, otherwise caches will overwrite each other.",
-          "default": "",
-          "defaultInfo": {
-            "environment": [
-              "buildkit"
-            ]
-          }
+          "default": "buildkit"
         },
         "token": {
           "type": "string",

--- a/provider/internal/cache.go
+++ b/provider/internal/cache.go
@@ -157,7 +157,7 @@ type CacheFromGitHubActions struct {
 func (c *CacheFromGitHubActions) Annotate(a infer.Annotator) {
 	a.SetDefault(&c.URL, "", "ACTIONS_CACHE_URL")
 	a.SetDefault(&c.Token, "", "ACTIONS_RUNTIME_TOKEN")
-	a.SetDefault(&c.Scope, "", "buildkit")
+	a.SetDefault(&c.Scope, "buildkit")
 
 	a.Describe(&c.URL, dedent(`
 		The cache server URL to use for artifacts.

--- a/sdk/dotnet/Inputs/CacheFromGitHubActionsArgs.cs
+++ b/sdk/dotnet/Inputs/CacheFromGitHubActionsArgs.cs
@@ -54,7 +54,7 @@ namespace Pulumi.DockerBuild.Inputs
 
         public CacheFromGitHubActionsArgs()
         {
-            Scope = Utilities.GetEnv("buildkit") ?? "";
+            Scope = "buildkit";
             Token = Utilities.GetEnv("ACTIONS_RUNTIME_TOKEN") ?? "";
             Url = Utilities.GetEnv("ACTIONS_CACHE_URL") ?? "";
         }

--- a/sdk/dotnet/Inputs/CacheToGitHubActionsArgs.cs
+++ b/sdk/dotnet/Inputs/CacheToGitHubActionsArgs.cs
@@ -68,7 +68,7 @@ namespace Pulumi.DockerBuild.Inputs
         {
             IgnoreError = false;
             Mode = Pulumi.DockerBuild.CacheMode.Min;
-            Scope = Utilities.GetEnv("buildkit") ?? "";
+            Scope = "buildkit";
             Token = Utilities.GetEnv("ACTIONS_RUNTIME_TOKEN") ?? "";
             Url = Utilities.GetEnv("ACTIONS_CACHE_URL") ?? "";
         }

--- a/sdk/go/dockerbuild/pulumiTypes.go
+++ b/sdk/go/dockerbuild/pulumiTypes.go
@@ -862,10 +862,8 @@ func (val *CacheFromGitHubActions) Defaults() *CacheFromGitHubActions {
 	}
 	tmp := *val
 	if tmp.Scope == nil {
-		if d := internal.GetEnvOrDefault("", nil, "buildkit"); d != nil {
-			scope_ := d.(string)
-			tmp.Scope = &scope_
-		}
+		scope_ := "buildkit"
+		tmp.Scope = &scope_
 	}
 	if tmp.Token == nil {
 		if d := internal.GetEnvOrDefault("", nil, "ACTIONS_RUNTIME_TOKEN"); d != nil {
@@ -921,9 +919,7 @@ func (val *CacheFromGitHubActionsArgs) Defaults() *CacheFromGitHubActionsArgs {
 	}
 	tmp := *val
 	if tmp.Scope == nil {
-		if d := internal.GetEnvOrDefault("", nil, "buildkit"); d != nil {
-			tmp.Scope = pulumi.StringPtr(d.(string))
-		}
+		tmp.Scope = pulumi.StringPtr("buildkit")
 	}
 	if tmp.Token == nil {
 		if d := internal.GetEnvOrDefault("", nil, "ACTIONS_RUNTIME_TOKEN"); d != nil {
@@ -2405,10 +2401,8 @@ func (val *CacheToGitHubActions) Defaults() *CacheToGitHubActions {
 		tmp.Mode = &mode_
 	}
 	if tmp.Scope == nil {
-		if d := internal.GetEnvOrDefault("", nil, "buildkit"); d != nil {
-			scope_ := d.(string)
-			tmp.Scope = &scope_
-		}
+		scope_ := "buildkit"
+		tmp.Scope = &scope_
 	}
 	if tmp.Token == nil {
 		if d := internal.GetEnvOrDefault("", nil, "ACTIONS_RUNTIME_TOKEN"); d != nil {
@@ -2474,9 +2468,7 @@ func (val *CacheToGitHubActionsArgs) Defaults() *CacheToGitHubActionsArgs {
 		tmp.Mode = CacheMode("min")
 	}
 	if tmp.Scope == nil {
-		if d := internal.GetEnvOrDefault("", nil, "buildkit"); d != nil {
-			tmp.Scope = pulumi.StringPtr(d.(string))
-		}
+		tmp.Scope = pulumi.StringPtr("buildkit")
 	}
 	if tmp.Token == nil {
 		if d := internal.GetEnvOrDefault("", nil, "ACTIONS_RUNTIME_TOKEN"); d != nil {

--- a/sdk/go/dockerbuild/x/pulumiTypes.go
+++ b/sdk/go/dockerbuild/x/pulumiTypes.go
@@ -421,10 +421,8 @@ func (val *CacheFromGitHubActions) Defaults() *CacheFromGitHubActions {
 	}
 	tmp := *val
 	if tmp.Scope == nil {
-		if d := internal.GetEnvOrDefault("", nil, "buildkit"); d != nil {
-			scope_ := d.(string)
-			tmp.Scope = &scope_
-		}
+		scope_ := "buildkit"
+		tmp.Scope = &scope_
 	}
 	if tmp.Token == nil {
 		if d := internal.GetEnvOrDefault("", nil, "ACTIONS_RUNTIME_TOKEN"); d != nil {
@@ -469,9 +467,7 @@ func (val *CacheFromGitHubActionsArgs) Defaults() *CacheFromGitHubActionsArgs {
 	}
 	tmp := *val
 	if tmp.Scope == nil {
-		if d := internal.GetEnvOrDefault("", nil, "buildkit"); d != nil {
-			tmp.Scope = pulumix.Ptr(d.(string))
-		}
+		tmp.Scope = pulumix.Ptr("buildkit")
 	}
 	if tmp.Token == nil {
 		if d := internal.GetEnvOrDefault("", nil, "ACTIONS_RUNTIME_TOKEN"); d != nil {
@@ -1178,10 +1174,8 @@ func (val *CacheToGitHubActions) Defaults() *CacheToGitHubActions {
 		tmp.Mode = &mode_
 	}
 	if tmp.Scope == nil {
-		if d := internal.GetEnvOrDefault("", nil, "buildkit"); d != nil {
-			scope_ := d.(string)
-			tmp.Scope = &scope_
-		}
+		scope_ := "buildkit"
+		tmp.Scope = &scope_
 	}
 	if tmp.Token == nil {
 		if d := internal.GetEnvOrDefault("", nil, "ACTIONS_RUNTIME_TOKEN"); d != nil {
@@ -1236,9 +1230,7 @@ func (val *CacheToGitHubActionsArgs) Defaults() *CacheToGitHubActionsArgs {
 		tmp.Mode = pulumix.Ptr(CacheMode("min"))
 	}
 	if tmp.Scope == nil {
-		if d := internal.GetEnvOrDefault("", nil, "buildkit"); d != nil {
-			tmp.Scope = pulumix.Ptr(d.(string))
-		}
+		tmp.Scope = pulumix.Ptr("buildkit")
 	}
 	if tmp.Token == nil {
 		if d := internal.GetEnvOrDefault("", nil, "ACTIONS_RUNTIME_TOKEN"); d != nil {

--- a/sdk/java/src/main/java/com/pulumi/dockerbuild/inputs/CacheFromGitHubActionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/dockerbuild/inputs/CacheFromGitHubActionsArgs.java
@@ -199,7 +199,7 @@ public final class CacheFromGitHubActionsArgs extends com.pulumi.resources.Resou
         }
 
         public CacheFromGitHubActionsArgs build() {
-            $.scope = Codegen.stringProp("scope").output().arg($.scope).env("buildkit").def("").getNullable();
+            $.scope = Codegen.stringProp("scope").output().arg($.scope).def("buildkit").getNullable();
             $.token = Codegen.stringProp("token").secret().arg($.token).env("ACTIONS_RUNTIME_TOKEN").def("").getNullable();
             $.url = Codegen.stringProp("url").output().arg($.url).env("ACTIONS_CACHE_URL").def("").getNullable();
             return $;

--- a/sdk/java/src/main/java/com/pulumi/dockerbuild/inputs/CacheToGitHubActionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/dockerbuild/inputs/CacheToGitHubActionsArgs.java
@@ -277,7 +277,7 @@ public final class CacheToGitHubActionsArgs extends com.pulumi.resources.Resourc
         public CacheToGitHubActionsArgs build() {
             $.ignoreError = Codegen.booleanProp("ignoreError").output().arg($.ignoreError).def(false).getNullable();
             $.mode = Codegen.objectProp("mode", CacheMode.class).output().arg($.mode).def(CacheMode.Min).getNullable();
-            $.scope = Codegen.stringProp("scope").output().arg($.scope).env("buildkit").def("").getNullable();
+            $.scope = Codegen.stringProp("scope").output().arg($.scope).def("buildkit").getNullable();
             $.token = Codegen.stringProp("token").secret().arg($.token).env("ACTIONS_RUNTIME_TOKEN").def("").getNullable();
             $.url = Codegen.stringProp("url").output().arg($.url).env("ACTIONS_CACHE_URL").def("").getNullable();
             return $;

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -136,7 +136,7 @@ export interface CacheFromGitHubActionsArgs {
 export function cacheFromGitHubActionsArgsProvideDefaults(val: CacheFromGitHubActionsArgs): CacheFromGitHubActionsArgs {
     return {
         ...val,
-        scope: (val.scope) ?? (utilities.getEnv("buildkit") || ""),
+        scope: (val.scope) ?? "buildkit",
         token: (val.token) ?? (utilities.getEnv("ACTIONS_RUNTIME_TOKEN") || ""),
         url: (val.url) ?? (utilities.getEnv("ACTIONS_CACHE_URL") || ""),
     };
@@ -345,7 +345,7 @@ export function cacheToGitHubActionsArgsProvideDefaults(val: CacheToGitHubAction
         ...val,
         ignoreError: (val.ignoreError) ?? false,
         mode: (val.mode) ?? "min",
-        scope: (val.scope) ?? (utilities.getEnv("buildkit") || ""),
+        scope: (val.scope) ?? "buildkit",
         token: (val.token) ?? (utilities.getEnv("ACTIONS_RUNTIME_TOKEN") || ""),
         url: (val.url) ?? (utilities.getEnv("ACTIONS_CACHE_URL") || ""),
     };

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -136,7 +136,7 @@ export interface CacheFromGitHubActions {
 export function cacheFromGitHubActionsProvideDefaults(val: CacheFromGitHubActions): CacheFromGitHubActions {
     return {
         ...val,
-        scope: (val.scope) ?? (utilities.getEnv("buildkit") || ""),
+        scope: (val.scope) ?? "buildkit",
         token: (val.token) ?? (utilities.getEnv("ACTIONS_RUNTIME_TOKEN") || ""),
         url: (val.url) ?? (utilities.getEnv("ACTIONS_CACHE_URL") || ""),
     };
@@ -345,7 +345,7 @@ export function cacheToGitHubActionsProvideDefaults(val: CacheToGitHubActions): 
         ...val,
         ignoreError: (val.ignoreError) ?? false,
         mode: (val.mode) ?? "min",
-        scope: (val.scope) ?? (utilities.getEnv("buildkit") || ""),
+        scope: (val.scope) ?? "buildkit",
         token: (val.token) ?? (utilities.getEnv("ACTIONS_RUNTIME_TOKEN") || ""),
         url: (val.url) ?? (utilities.getEnv("ACTIONS_CACHE_URL") || ""),
     };

--- a/sdk/python/pulumi_docker_build/_inputs.py
+++ b/sdk/python/pulumi_docker_build/_inputs.py
@@ -332,7 +332,7 @@ class CacheFromGitHubActionsArgs:
                environment variable to your jobs.
         """
         if scope is None:
-            scope = (_utilities.get_env('buildkit') or '')
+            scope = 'buildkit'
         if scope is not None:
             pulumi.set(__self__, "scope", scope)
         if token is None:
@@ -1048,7 +1048,7 @@ class CacheToGitHubActionsArgs:
         if mode is not None:
             pulumi.set(__self__, "mode", mode)
         if scope is None:
-            scope = (_utilities.get_env('buildkit') or '')
+            scope = 'buildkit'
         if scope is not None:
             pulumi.set(__self__, "scope", scope)
         if token is None:

--- a/sdk/python/pulumi_docker_build/outputs.py
+++ b/sdk/python/pulumi_docker_build/outputs.py
@@ -315,7 +315,7 @@ class CacheFromGitHubActions(dict):
                environment variable to your jobs.
         """
         if scope is None:
-            scope = (_utilities.get_env('buildkit') or '')
+            scope = 'buildkit'
         if scope is not None:
             pulumi.set(__self__, "scope", scope)
         if token is None:
@@ -835,7 +835,7 @@ class CacheToGitHubActions(dict):
         if mode is not None:
             pulumi.set(__self__, "mode", mode)
         if scope is None:
-            scope = (_utilities.get_env('buildkit') or '')
+            scope = 'buildkit'
         if scope is not None:
             pulumi.set(__self__, "scope", scope)
         if token is None:


### PR DESCRIPTION

This PR updates the schema to use the correct default value for `scope` in the GHA caching options.  This should be effectively a no-op.


From: https://docs.docker.com/build/cache/backends/gha/

<img width="892" alt="image" src="https://github.com/user-attachments/assets/690cde79-e30e-4085-81fd-1c9dc1c6d7e9" />


Closes #496 