### PR TITLE
chore: pin golangci-lint to latest v1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ ${PULUMI}: go.sum
 	GOBIN=${WORKING_DIR}/bin go install github.com/pulumi/pulumi-yaml/cmd/pulumi-converter-yaml
 
 ${GOGLANGCILINT}: go.sum
-	GOBIN=${WORKING_DIR}/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	GOBIN=${WORKING_DIR}/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@8b37f14
 
 define pulumi_login
     export PULUMI_CONFIG_PASSPHRASE=asdfqwerty1234; \


### PR DESCRIPTION
This PR pins the installation of golangci-lint to the latest v1 release (v1.64.8). Installing from latest pulls in v2 changes that causes a runtime panic when running locally.