### PR TITLE
Flow `context.Context` through image builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- Respond to cancel for exec builds. (<https://github.com/pulumi/pulumi-docker-build/pull/522>)
+
 ## 0.0.11 (2025-04-11)
 
 ### Added

--- a/provider/internal/cli_test.go
+++ b/provider/internal/cli_test.go
@@ -28,12 +28,12 @@ import (
 func TestExec(t *testing.T) {
 	t.Parallel()
 
-	h, err := newHost(context.Background(), nil)
+	h, err := newHost(t.Context(), nil)
 	require.NoError(t, err)
 	cli, err := wrap(h)
 	require.NoError(t, err)
 
-	err = cli.exec([]string{"buildx", "version"}, nil)
+	err = cli.exec(t.Context(), []string{"buildx", "version"}, nil)
 	assert.NoError(t, err)
 
 	out, err := io.ReadAll(cli.r)

--- a/provider/internal/client.go
+++ b/provider/internal/client.go
@@ -106,10 +106,10 @@ func (c *cli) Build(
 	defer contract.IgnoreClose(c)
 
 	if build.ShouldExec() {
-		return c.execBuild(build)
+		return c.execBuild(ctx, build)
 	}
 
-	b, err := c.host.builderFor(build)
+	b, err := c.host.builderFor(ctx, build)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This should help with cancel responsiveness. Right now, there are multiple places where docker does not respond to cancel for long periods of time.