### PR TITLE
Restore yaml build tag

### DIFF
--- a/examples/yaml_test.go
+++ b/examples/yaml_test.go
@@ -1,3 +1,6 @@
+//go:build yaml || all
+// +build yaml all
+
 package examples
 
 import (


### PR DESCRIPTION
I suspect this was removed accidentally in #490. Without this tag we run the tests on every language shard, so let's restore it.