### PR TITLE
Unit testing example

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/otiai10/copy v1.14.0
 	github.com/pulumi/providertest v0.3.1
 	github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3 v3.0.0-20250507122953-af68281fea7f
-	github.com/pulumi/pulumi-go-provider v1.0.0-rc1.0.20250509163142-82c9935ceef4
+	github.com/pulumi/pulumi-go-provider v1.0.0-rc1.0.20250508214503-b09e1ae91a79
 	github.com/pulumi/pulumi-java/pkg v1.11.0
 	github.com/pulumi/pulumi-yaml v1.17.0
 	github.com/pulumi/pulumi/pkg/v3 v3.169.0

--- a/go.sum
+++ b/go.sum
@@ -950,8 +950,8 @@ github.com/pulumi/providertest v0.3.1 h1:vlftr7TZlObh81mL88IhhF0/9ZbLrZZos4NAvR4
 github.com/pulumi/providertest v0.3.1/go.mod h1:fFHUP4/9DRyYnHWiRnwcynMtM/a7hHR/QcJfcuZKO3A=
 github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3 v3.0.0-20250507122953-af68281fea7f h1:2Lwj2Aefzs1nQu5HTePcO4WnynkV+wn9knjvexV0LUE=
 github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3 v3.0.0-20250507122953-af68281fea7f/go.mod h1:hxBlJXAULwXhJR3hMRoJvWuXjVHCUbDVrLMfkELfVdk=
-github.com/pulumi/pulumi-go-provider v1.0.0-rc1.0.20250509163142-82c9935ceef4 h1:JTnT/7lT/sfmmYMzSkiT6VBxY2Fjv2OHITMl/3sLvH4=
-github.com/pulumi/pulumi-go-provider v1.0.0-rc1.0.20250509163142-82c9935ceef4/go.mod h1:iBuN17+kkUL0GpXftmBxtwZFWsdyV8W34mGouk2/8bg=
+github.com/pulumi/pulumi-go-provider v1.0.0-rc1.0.20250508214503-b09e1ae91a79 h1:BYFzRYAUACLa+vfNBJd1okoJnH0H49q547e2f8kddHw=
+github.com/pulumi/pulumi-go-provider v1.0.0-rc1.0.20250508214503-b09e1ae91a79/go.mod h1:nHe4CydeeIK5LlrrRk/fGBB3n+KTpjNWCrph3FGaJ7Q=
 github.com/pulumi/pulumi-java/pkg v1.11.0 h1:M8C7CKxwBSE/c5RcoGF0sAUSFZywjd7CjmTRQh8nvNk=
 github.com/pulumi/pulumi-java/pkg v1.11.0/go.mod h1:zoQdTjj488DhUx8dNed6SW1fJnAE4GwGLBVDRpsQVE8=
 github.com/pulumi/pulumi-yaml v1.17.0 h1:ebzggygqBcQrtmdBUqi28B1L/fAyHCFVIt0dS5re8Oc=

--- a/provider/internal/image.go
+++ b/provider/internal/image.go
@@ -61,7 +61,9 @@ var _imageExamples string
 var _migration string
 
 // Image is a Docker image build using buildkit.
-type Image struct{}
+type Image struct {
+	docker Client
+}
 
 // Annotate provides a description of the Image resource.
 func (i *Image) Annotate(a infer.Annotator) {
@@ -330,11 +332,12 @@ func (is *ImageState) Annotate(a infer.Annotator) {
 // client produces a CLI client scoped to this resource and layered on top of
 // any host-level credentials.
 func (i *Image) client(ctx context.Context, state ImageState, args ImageArgs) (Client, error) {
-	cfg := infer.GetConfig[Config](ctx)
-
-	if cli, ok := ctx.Value(_mockClientKey).(Client); ok {
-		return cli, nil
+	// Use our mock client, if it's set.
+	if i.docker != nil {
+		return i.docker, nil
 	}
+
+	cfg := infer.GetConfig[Config](ctx)
 
 	// We prefer auth from args, the provider, and state in that order. We
 	// build a slice in reverse order because wrap() will overwrite earlier

--- a/provider/internal/image_test.go
+++ b/provider/internal/image_test.go
@@ -353,22 +353,17 @@ func TestDelete(t *testing.T) {
 			Delete(gomock.Any(), "docker.io/pulumi/test@sha256:foo").
 			Return(errNotFound{})
 
-		s := newServer(t.Context(), t, client)
-		err := s.Configure(provider.ConfigureRequest{})
-		require.NoError(t, err)
+		i := &Image{docker: client}
 
-		err = s.Delete(provider.DeleteRequest{
-			ID:  "foo,bar",
-			Urn: _fakeURN,
-			Properties: property.NewMap(map[string]property.Value{
-				"tags": property.New([]property.Value{
-					property.New("docker.io/pulumi/test:foo"),
-				}),
-				"push":        property.New(true),
-				"digest":      property.New("sha256:foo"),
-				"contextHash": property.New(""),
-				"ref":         property.New(""),
-			}),
+		_, err := i.Delete(t.Context(), infer.DeleteRequest[ImageState]{
+			ID: "foo,bar",
+			State: ImageState{
+				ImageArgs: ImageArgs{
+					Tags: []string{"docker.io/pulumi/test:foo"},
+					Push: true,
+				},
+				Digest: "sha256:foo",
+			},
 		})
 		assert.NoError(t, err)
 	})

--- a/provider/internal/image_test.go
+++ b/provider/internal/image_test.go
@@ -28,7 +28,6 @@ import (
 	pb "github.com/docker/buildx/controller/pb"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
-	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/stretchr/testify/assert"
@@ -36,6 +35,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	provider "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper"

--- a/provider/internal/index.go
+++ b/provider/internal/index.go
@@ -48,6 +48,7 @@ var _indexExamples string
 // Index is an OCI index or manifest list on a remote registry.
 type Index struct {
 	docker Client
+	config *Config
 }
 
 // IndexArgs instantiate an Index.
@@ -349,7 +350,7 @@ func (i *Index) Diff(
 // client produces a CLI client scoped to this resource and layered on top of
 // any host-level credentials.
 func (i *Index) client(
-	ctx context.Context,
+	_ context.Context,
 	_ IndexState,
 	args IndexArgs,
 ) (Client, error) {
@@ -358,16 +359,14 @@ func (i *Index) client(
 		return i.docker, nil
 	}
 
-	cfg := infer.GetConfig[Config](ctx)
-
 	// We prefer auth from args, the provider, and state in that order. We
 	// build a slice in reverse order because wrap() will overwrite earlier
 	// entries with later ones.
 	auths := []Registry{}
-	auths = append(auths, cfg.Registries...)
+	auths = append(auths, i.config.Registries...)
 	if args.Registry != nil {
 		auths = append(auths, *args.Registry)
 	}
 
-	return wrap(cfg.host, auths...)
+	return wrap(i.config.host, auths...)
 }

--- a/provider/internal/index.go
+++ b/provider/internal/index.go
@@ -46,7 +46,9 @@ var (
 var _indexExamples string
 
 // Index is an OCI index or manifest list on a remote registry.
-type Index struct{}
+type Index struct {
+	docker Client
+}
 
 // IndexArgs instantiate an Index.
 type IndexArgs struct {
@@ -351,11 +353,12 @@ func (i *Index) client(
 	_ IndexState,
 	args IndexArgs,
 ) (Client, error) {
-	cfg := infer.GetConfig[Config](ctx)
-
-	if cli, ok := ctx.Value(_mockClientKey).(Client); ok {
-		return cli, nil
+	// Use our mock client, if it's set.
+	if i.docker != nil {
+		return i.docker, nil
 	}
+
+	cfg := infer.GetConfig[Config](ctx)
 
 	// We prefer auth from args, the provider, and state in that order. We
 	// build a slice in reverse order because wrap() will overwrite earlier

--- a/provider/internal/provider.go
+++ b/provider/internal/provider.go
@@ -64,6 +64,8 @@ func (c *Config) Configure(ctx context.Context) error {
 
 // NewBuildxProvider returns a new buildx provider.
 func NewBuildxProvider(mock Client) provider.Provider {
+	config := &Config{}
+
 	prov := infer.Provider(
 		infer.Options{
 			Metadata: pschema.Metadata{
@@ -111,13 +113,13 @@ func NewBuildxProvider(mock Client) provider.Provider {
 				},
 			},
 			Resources: []infer.InferredResource{
-				infer.Resource(&Image{docker: mock}),
-				infer.Resource(&Index{docker: mock}),
+				infer.Resource(&Image{docker: mock, config: config}),
+				infer.Resource(&Index{docker: mock, config: config}),
 			},
 			ModuleMap: map[tokens.ModuleName]tokens.ModuleName{
 				"internal": "index",
 			},
-			Config: infer.Config(&Config{}),
+			Config: infer.Config(config),
 		},
 	)
 

--- a/provider/internal/provider_test.go
+++ b/provider/internal/provider_test.go
@@ -25,7 +25,6 @@ import (
 	provider "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/integration"
-	mwcontext "github.com/pulumi/pulumi-go-provider/middleware/context"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
@@ -79,14 +78,7 @@ func (annotator) SetResourceDeprecationMessage(_ string)      {}
 func newServer(ctx context.Context, t *testing.T, client Client) integration.Server {
 	t.Helper()
 
-	p := NewBuildxProvider()
-
-	// Inject a mock client if provided.
-	if client != nil {
-		p = mwcontext.Wrap(p, func(ctx context.Context) context.Context {
-			return context.WithValue(ctx, _mockClientKey, client)
-		})
-	}
+	p := NewBuildxProvider(client)
 
 	s, err := integration.NewServer(
 		ctx,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -34,5 +34,5 @@ func Serve() error {
 
 // New creates a new provider.
 func New(host *provider.HostClient) (rpc.ResourceProviderServer, error) {
-	return gp.RawServer(Name, Version, internal.NewBuildxProvider())(host)
+	return gp.RawServer(Name, Version, internal.NewBuildxProvider(nil))(host)
 }


### PR DESCRIPTION
Example of unit testing with API changes in https://github.com/pulumi/pulumi-go-provider/pull/365. This doesn't replace integration tests but can compliment them.

* `ctx` is no longer required to have all relevant values injected via middleware, so units can be tested with explicit config and resource state. Helpful if you would have previously required several prerequisite operations to get into that state.
* Unit tests work with the user-defined (and type-safe!) structs instead of property maps. I had a bug in one of my tests because `Get()` was always returning a non-nil value.

Re-writing Read made me realize I don't really understand why this takes input and state -- what are the inputs? Edit: something to do with imports, but we should do a better job spelling this out for the user. I'm guessing this provider has import bugs as a result.