### PR TITLE
Freeze v0.0.12

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -6,8 +6,6 @@ on:
     types:
     - run-acceptance-tests-command
   pull_request:
-    paths-ignore:
-    - CHANGELOG.md
   workflow_dispatch: {}
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 ## Unreleased
 
+## 0.0.12 (2025-05-16)
+
 ### Changed
 
-- Respond to cancel for exec builds. (<https://github.com/pulumi/pulumi-docker-build/pull/522>)
+- Upgraded pulumi-go-provider to v1.0.0-rc2.
 
 ### Fixed
 
-- Builds now respect cancellation. (https://github.com/pulumi/pulumi-docker-build/issues/533)
+- Builds now respect cancellation. (https://github.com/pulumi/pulumi-docker-build/issues/533, https://github.com/pulumi/pulumi-docker-build/pull/522)
 
 ## 0.0.11 (2025-04-11)
 


### PR DESCRIPTION
## 0.0.12 (2025-05-16)

### Changed

- Upgraded pulumi-go-provider to v1.0.0-rc2.

### Fixed

- Builds now respect cancellation. (https://github.com/pulumi/pulumi-docker-build/issues/533, https://github.com/pulumi/pulumi-docker-build/pull/522)