### PR TITLE
Update golangci-lint version to 2 via mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+golangci-lint = "2.5.0"
+go = "1.25.1"


### PR DESCRIPTION
Fixes #636 

Should be merged after: https://github.com/pulumi/ci-mgmt/pull/1811

---

Co-authored-by: @Zaid-Ajaj