### PR TITLE
add IgnoreSecretsInDiffCalculation argument to avoid rebuilds if short-lived secrets change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Arguments `CacheFromGitHubActions.URL` and `CacheFromGitHubActions.Token` have been removed. If the previous behaviour is desired, set the `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` environment variables. (https://github.com/pulumi/pulumi-docker-build/issues/75)
+- Argument `IgnoreSecretsInDiffCalculation` has been added to avoid unnecessary rebuilds in case short-lived secrets change. (https://github.com/pulumi/pulumi-docker-build/issues/678)
 
 ## 0.0.14 (2025-09-30)
 

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ go.mod: $(shell find . -name '*.go')
 go.sum: go.mod
 
 sdk: $(shell mkdir -p sdk)
-sdk: sdk/python sdk/nodejs sdk/java sdk/python sdk/go sdk/dotnet
+sdk: sdk/python sdk/nodejs sdk/java sdk/go sdk/dotnet
 
 # Folders can't be used for up-to-date checks as they will be marked as up-to-date even if the step fails - leading to a broken state.
 .PHONY: sdk/*

--- a/provider/cmd/pulumi-resource-docker-build/schema.json
+++ b/provider/cmd/pulumi-resource-docker-build/schema.json
@@ -1136,6 +1136,13 @@
           },
           "description": "Controls where images are persisted after building.\n\nImages are only stored in the local cache unless `exports` are\nexplicitly configured.\n\nExporting to multiple destinations requires a daemon running BuildKit\n0.13 or later.\n\nEquivalent to Docker's `--output` flag."
         },
+        "ignoreSecretsInDiffCalculation": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of secret names to ignore when calculating diffs.\n\nThese secrets will not be considered when calculating diffs, even if they\nare changed. Note: only applicable if the secret is present in both the old and the new state.\n\nThis is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run."
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
@@ -1270,6 +1277,13 @@
             "$ref": "#/types/docker-build:index:Export"
           },
           "description": "Controls where images are persisted after building.\n\nImages are only stored in the local cache unless `exports` are\nexplicitly configured.\n\nExporting to multiple destinations requires a daemon running BuildKit\n0.13 or later.\n\nEquivalent to Docker's `--output` flag."
+        },
+        "ignoreSecretsInDiffCalculation": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of secret names to ignore when calculating diffs.\n\nThese secrets will not be considered when calculating diffs, even if they\nare changed. Note: only applicable if the secret is present in both the old and the new state.\n\nThis is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run."
         },
         "labels": {
           "type": "object",

--- a/provider/internal/image.go
+++ b/provider/internal/image.go
@@ -426,6 +426,8 @@ func (ia *ImageArgs) normalize(preview bool) ImageArgs {
 		Secrets:        mapKeeper{preview}.keep(ia.Secrets),
 		Tags:           filter(stringKeeper{preview}, ia.Tags...),
 		Target:         ia.Target,
+
+		IgnoreSecretsInDiffCalculation: ia.IgnoreSecretsInDiffCalculation,
 	}
 
 	// Handle --push/--load shorthand.

--- a/provider/internal/image.go
+++ b/provider/internal/image.go
@@ -236,7 +236,7 @@ func (ia *ImageArgs) Annotate(a infer.Annotator) {
 		These secrets will not be considered when calculating diffs, even if they
 		are changed. Note: only applicable if the secret is present in both the old and the new state.
 
-		This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+		This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 	`))
 	a.Describe(&ia.SSH, dedent(`
 		SSH agent socket or keys to expose to the build.

--- a/provider/internal/image_test.go
+++ b/provider/internal/image_test.go
@@ -750,6 +750,60 @@ func TestImageDiff(t *testing.T) {
 			wantChanges: true,
 		},
 		{
+			name: "diff if secrets change but ignoreSecretsInDiffCalculation is set",
+			state: func(_ *testing.T, s ImageState) ImageState {
+				s.Secrets = map[string]string{"foo": "old_bar"}
+				s.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return s
+			},
+			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
+				a.Secrets = map[string]string{"foo": "new_bar"}
+				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return a
+			},
+			wantChanges: false,
+		},
+		{
+			name: "diff if secrets change but ignoreSecretsInDiffCalculation is set for another secret",
+			state: func(_ *testing.T, s ImageState) ImageState {
+				s.Secrets = map[string]string{"foo": "old_bar"}
+				s.IgnoreSecretsInDiffCalculation = []string{"not_foo"}
+				return s
+			},
+			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
+				a.Secrets = map[string]string{"foo": "new_bar"}
+				a.IgnoreSecretsInDiffCalculation = []string{"not_foo"}
+				return a
+			},
+			wantChanges: true,
+		},
+		{
+			name: "diff if secrets change but ignoreSecretsInDiffCalculation is set and secret is added",
+			state: func(_ *testing.T, s ImageState) ImageState {
+				s.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return s
+			},
+			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
+				a.Secrets = map[string]string{"foo": "bar"}
+				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return a
+			},
+			wantChanges: true,
+		},
+		{
+			name: "diff if secrets change but ignoreSecretsInDiffCalculation is set and secret is removed",
+			state: func(_ *testing.T, s ImageState) ImageState {
+				s.Secrets = map[string]string{"foo": "bar"}
+				s.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return s
+			},
+			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
+				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return a
+			},
+			wantChanges: true,
+		},
+		{
 			name: "diff if local export doesn't exist",
 			state: func(_ *testing.T, state ImageState) ImageState {
 				state.Exports = []Export{

--- a/provider/internal/image_test.go
+++ b/provider/internal/image_test.go
@@ -804,6 +804,33 @@ func TestImageDiff(t *testing.T) {
 			wantChanges: true,
 		},
 		{
+			name: "diff if an ignored secret and a non-ignored secret both change",
+			state: func(_ *testing.T, s ImageState) ImageState {
+				s.Secrets = map[string]string{"foo": "old_foo", "bar": "old_bar"}
+				s.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return s
+			},
+			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
+				a.Secrets = map[string]string{"foo": "new_foo", "bar": "new_bar"}
+				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return a
+			},
+			wantChanges: true,
+		},
+		{
+			name: "no diff if only ignoreSecretsInDiffCalculation changes",
+			state: func(_ *testing.T, s ImageState) ImageState {
+				s.Secrets = map[string]string{"foo": "bar"}
+				return s
+			},
+			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
+				a.Secrets = map[string]string{"foo": "bar"}
+				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				return a
+			},
+			wantChanges: false,
+		},
+		{
 			name: "diff if local export doesn't exist",
 			state: func(_ *testing.T, state ImageState) ImageState {
 				state.Exports = []Export{

--- a/provider/internal/image_test.go
+++ b/provider/internal/image_test.go
@@ -1148,6 +1148,15 @@ func TestBuildable(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "known with ignoreSecretsInDiffCalculation set",
+			args: ImageArgs{
+				Tags:                           []string{"known"},
+				Secrets:                        map[string]string{"foo": "bar"},
+				IgnoreSecretsInDiffCalculation: []string{"foo"},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sdk/dotnet/Image.cs
+++ b/sdk/dotnet/Image.cs
@@ -632,6 +632,17 @@ namespace Pulumi.DockerBuild
         public Output<ImmutableArray<Outputs.Export>> Exports { get; private set; } = null!;
 
         /// <summary>
+        /// A list of secret names to ignore when calculating diffs.
+        /// 
+        /// These secrets will not be considered when calculating diffs, even if they
+        /// are changed. Note: only applicable if the secret is present in both the old and the new state.
+        /// 
+        /// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+        /// </summary>
+        [Output("ignoreSecretsInDiffCalculation")]
+        public Output<ImmutableArray<string>> IgnoreSecretsInDiffCalculation { get; private set; } = null!;
+
+        /// <summary>
         /// Attach arbitrary key/value metadata to the image.
         /// 
         /// Equivalent to Docker's `--label` flag.
@@ -955,6 +966,23 @@ namespace Pulumi.DockerBuild
         {
             get => _exports ?? (_exports = new InputList<Inputs.ExportArgs>());
             set => _exports = value;
+        }
+
+        [Input("ignoreSecretsInDiffCalculation")]
+        private InputList<string>? _ignoreSecretsInDiffCalculation;
+
+        /// <summary>
+        /// A list of secret names to ignore when calculating diffs.
+        /// 
+        /// These secrets will not be considered when calculating diffs, even if they
+        /// are changed. Note: only applicable if the secret is present in both the old and the new state.
+        /// 
+        /// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+        /// </summary>
+        public InputList<string> IgnoreSecretsInDiffCalculation
+        {
+            get => _ignoreSecretsInDiffCalculation ?? (_ignoreSecretsInDiffCalculation = new InputList<string>());
+            set => _ignoreSecretsInDiffCalculation = value;
         }
 
         [Input("labels")]

--- a/sdk/dotnet/Image.cs
+++ b/sdk/dotnet/Image.cs
@@ -637,7 +637,7 @@ namespace Pulumi.DockerBuild
         /// These secrets will not be considered when calculating diffs, even if they
         /// are changed. Note: only applicable if the secret is present in both the old and the new state.
         /// 
-        /// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+        /// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
         /// </summary>
         [Output("ignoreSecretsInDiffCalculation")]
         public Output<ImmutableArray<string>> IgnoreSecretsInDiffCalculation { get; private set; } = null!;
@@ -977,7 +977,7 @@ namespace Pulumi.DockerBuild
         /// These secrets will not be considered when calculating diffs, even if they
         /// are changed. Note: only applicable if the secret is present in both the old and the new state.
         /// 
-        /// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+        /// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
         /// </summary>
         public InputList<string> IgnoreSecretsInDiffCalculation
         {

--- a/sdk/go/dockerbuild/image.go
+++ b/sdk/go/dockerbuild/image.go
@@ -633,6 +633,13 @@ type Image struct {
 	//
 	// Equivalent to Docker's `--output` flag.
 	Exports ExportArrayOutput `pulumi:"exports"`
+	// A list of secret names to ignore when calculating diffs.
+	//
+	// These secrets will not be considered when calculating diffs, even if they
+	// are changed. Note: only applicable if the secret is present in both the old and the new state.
+	//
+	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	IgnoreSecretsInDiffCalculation pulumi.StringArrayOutput `pulumi:"ignoreSecretsInDiffCalculation"`
 	// Attach arbitrary key/value metadata to the image.
 	//
 	// Equivalent to Docker's `--label` flag.
@@ -843,6 +850,13 @@ type imageArgs struct {
 	//
 	// Equivalent to Docker's `--output` flag.
 	Exports []Export `pulumi:"exports"`
+	// A list of secret names to ignore when calculating diffs.
+	//
+	// These secrets will not be considered when calculating diffs, even if they
+	// are changed. Note: only applicable if the secret is present in both the old and the new state.
+	//
+	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	IgnoreSecretsInDiffCalculation []string `pulumi:"ignoreSecretsInDiffCalculation"`
 	// Attach arbitrary key/value metadata to the image.
 	//
 	// Equivalent to Docker's `--label` flag.
@@ -991,6 +1005,13 @@ type ImageArgs struct {
 	//
 	// Equivalent to Docker's `--output` flag.
 	Exports ExportArrayInput
+	// A list of secret names to ignore when calculating diffs.
+	//
+	// These secrets will not be considered when calculating diffs, even if they
+	// are changed. Note: only applicable if the secret is present in both the old and the new state.
+	//
+	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	IgnoreSecretsInDiffCalculation pulumi.StringArrayInput
 	// Attach arbitrary key/value metadata to the image.
 	//
 	// Equivalent to Docker's `--label` flag.
@@ -1232,6 +1253,16 @@ func (o ImageOutput) Exec() pulumi.BoolPtrOutput {
 // Equivalent to Docker's `--output` flag.
 func (o ImageOutput) Exports() ExportArrayOutput {
 	return o.ApplyT(func(v *Image) ExportArrayOutput { return v.Exports }).(ExportArrayOutput)
+}
+
+// A list of secret names to ignore when calculating diffs.
+//
+// These secrets will not be considered when calculating diffs, even if they
+// are changed. Note: only applicable if the secret is present in both the old and the new state.
+//
+// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+func (o ImageOutput) IgnoreSecretsInDiffCalculation() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringArrayOutput { return v.IgnoreSecretsInDiffCalculation }).(pulumi.StringArrayOutput)
 }
 
 // Attach arbitrary key/value metadata to the image.

--- a/sdk/go/dockerbuild/image.go
+++ b/sdk/go/dockerbuild/image.go
@@ -638,7 +638,7 @@ type Image struct {
 	// These secrets will not be considered when calculating diffs, even if they
 	// are changed. Note: only applicable if the secret is present in both the old and the new state.
 	//
-	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 	IgnoreSecretsInDiffCalculation pulumi.StringArrayOutput `pulumi:"ignoreSecretsInDiffCalculation"`
 	// Attach arbitrary key/value metadata to the image.
 	//
@@ -855,7 +855,7 @@ type imageArgs struct {
 	// These secrets will not be considered when calculating diffs, even if they
 	// are changed. Note: only applicable if the secret is present in both the old and the new state.
 	//
-	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 	IgnoreSecretsInDiffCalculation []string `pulumi:"ignoreSecretsInDiffCalculation"`
 	// Attach arbitrary key/value metadata to the image.
 	//
@@ -1010,7 +1010,7 @@ type ImageArgs struct {
 	// These secrets will not be considered when calculating diffs, even if they
 	// are changed. Note: only applicable if the secret is present in both the old and the new state.
 	//
-	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 	IgnoreSecretsInDiffCalculation pulumi.StringArrayInput
 	// Attach arbitrary key/value metadata to the image.
 	//
@@ -1260,7 +1260,7 @@ func (o ImageOutput) Exports() ExportArrayOutput {
 // These secrets will not be considered when calculating diffs, even if they
 // are changed. Note: only applicable if the secret is present in both the old and the new state.
 //
-// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 func (o ImageOutput) IgnoreSecretsInDiffCalculation() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Image) pulumi.StringArrayOutput { return v.IgnoreSecretsInDiffCalculation }).(pulumi.StringArrayOutput)
 }

--- a/sdk/go/dockerbuild/x/image.go
+++ b/sdk/go/dockerbuild/x/image.go
@@ -633,6 +633,13 @@ type Image struct {
 	//
 	// Equivalent to Docker's `--output` flag.
 	Exports pulumix.GArrayOutput[Export, ExportOutput] `pulumi:"exports"`
+	// A list of secret names to ignore when calculating diffs.
+	//
+	// These secrets will not be considered when calculating diffs, even if they
+	// are changed. Note: only applicable if the secret is present in both the old and the new state.
+	//
+	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	IgnoreSecretsInDiffCalculation pulumix.ArrayOutput[string] `pulumi:"ignoreSecretsInDiffCalculation"`
 	// Attach arbitrary key/value metadata to the image.
 	//
 	// Equivalent to Docker's `--label` flag.
@@ -843,6 +850,13 @@ type imageArgs struct {
 	//
 	// Equivalent to Docker's `--output` flag.
 	Exports []Export `pulumi:"exports"`
+	// A list of secret names to ignore when calculating diffs.
+	//
+	// These secrets will not be considered when calculating diffs, even if they
+	// are changed. Note: only applicable if the secret is present in both the old and the new state.
+	//
+	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	IgnoreSecretsInDiffCalculation []string `pulumi:"ignoreSecretsInDiffCalculation"`
 	// Attach arbitrary key/value metadata to the image.
 	//
 	// Equivalent to Docker's `--label` flag.
@@ -991,6 +1005,13 @@ type ImageArgs struct {
 	//
 	// Equivalent to Docker's `--output` flag.
 	Exports pulumix.Input[[]*ExportArgs]
+	// A list of secret names to ignore when calculating diffs.
+	//
+	// These secrets will not be considered when calculating diffs, even if they
+	// are changed. Note: only applicable if the secret is present in both the old and the new state.
+	//
+	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	IgnoreSecretsInDiffCalculation pulumix.Input[[]string]
 	// Attach arbitrary key/value metadata to the image.
 	//
 	// Equivalent to Docker's `--label` flag.
@@ -1227,6 +1248,18 @@ func (o ImageOutput) Exports() pulumix.GArrayOutput[Export, ExportOutput] {
 	value := pulumix.Apply[Image](o, func(v Image) pulumix.GArrayOutput[Export, ExportOutput] { return v.Exports })
 	unwrapped := pulumix.Flatten[[]Export, pulumix.GArrayOutput[Export, ExportOutput]](value)
 	return pulumix.GArrayOutput[Export, ExportOutput]{OutputState: unwrapped.OutputState}
+}
+
+// A list of secret names to ignore when calculating diffs.
+//
+// These secrets will not be considered when calculating diffs, even if they
+// are changed. Note: only applicable if the secret is present in both the old and the new state.
+//
+// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+func (o ImageOutput) IgnoreSecretsInDiffCalculation() pulumix.ArrayOutput[string] {
+	value := pulumix.Apply[Image](o, func(v Image) pulumix.ArrayOutput[string] { return v.IgnoreSecretsInDiffCalculation })
+	unwrapped := pulumix.Flatten[[]string, pulumix.ArrayOutput[string]](value)
+	return pulumix.ArrayOutput[string]{OutputState: unwrapped.OutputState}
 }
 
 // Attach arbitrary key/value metadata to the image.

--- a/sdk/go/dockerbuild/x/image.go
+++ b/sdk/go/dockerbuild/x/image.go
@@ -638,7 +638,7 @@ type Image struct {
 	// These secrets will not be considered when calculating diffs, even if they
 	// are changed. Note: only applicable if the secret is present in both the old and the new state.
 	//
-	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 	IgnoreSecretsInDiffCalculation pulumix.ArrayOutput[string] `pulumi:"ignoreSecretsInDiffCalculation"`
 	// Attach arbitrary key/value metadata to the image.
 	//
@@ -855,7 +855,7 @@ type imageArgs struct {
 	// These secrets will not be considered when calculating diffs, even if they
 	// are changed. Note: only applicable if the secret is present in both the old and the new state.
 	//
-	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 	IgnoreSecretsInDiffCalculation []string `pulumi:"ignoreSecretsInDiffCalculation"`
 	// Attach arbitrary key/value metadata to the image.
 	//
@@ -1010,7 +1010,7 @@ type ImageArgs struct {
 	// These secrets will not be considered when calculating diffs, even if they
 	// are changed. Note: only applicable if the secret is present in both the old and the new state.
 	//
-	// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+	// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 	IgnoreSecretsInDiffCalculation pulumix.Input[[]string]
 	// Attach arbitrary key/value metadata to the image.
 	//
@@ -1255,7 +1255,7 @@ func (o ImageOutput) Exports() pulumix.GArrayOutput[Export, ExportOutput] {
 // These secrets will not be considered when calculating diffs, even if they
 // are changed. Note: only applicable if the secret is present in both the old and the new state.
 //
-// This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+// This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
 func (o ImageOutput) IgnoreSecretsInDiffCalculation() pulumix.ArrayOutput[string] {
 	value := pulumix.Apply[Image](o, func(v Image) pulumix.ArrayOutput[string] { return v.IgnoreSecretsInDiffCalculation })
 	unwrapped := pulumix.Flatten[[]string, pulumix.ArrayOutput[string]](value)

--- a/sdk/java/src/main/java/com/pulumi/dockerbuild/Image.java
+++ b/sdk/java/src/main/java/com/pulumi/dockerbuild/Image.java
@@ -934,6 +934,30 @@ public class Image extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.exports);
     }
     /**
+     * A list of secret names to ignore when calculating diffs.
+     * 
+     * These secrets will not be considered when calculating diffs, even if they
+     * are changed. Note: only applicable if the secret is present in both the old and the new state.
+     * 
+     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * 
+     */
+    @Export(name="ignoreSecretsInDiffCalculation", refs={List.class,String.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<String>> ignoreSecretsInDiffCalculation;
+
+    /**
+     * @return A list of secret names to ignore when calculating diffs.
+     * 
+     * These secrets will not be considered when calculating diffs, even if they
+     * are changed. Note: only applicable if the secret is present in both the old and the new state.
+     * 
+     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * 
+     */
+    public Output<Optional<List<String>>> ignoreSecretsInDiffCalculation() {
+        return Codegen.optional(this.ignoreSecretsInDiffCalculation);
+    }
+    /**
      * Attach arbitrary key/value metadata to the image.
      * 
      * Equivalent to Docker&#39;s `--label` flag.

--- a/sdk/java/src/main/java/com/pulumi/dockerbuild/Image.java
+++ b/sdk/java/src/main/java/com/pulumi/dockerbuild/Image.java
@@ -939,7 +939,7 @@ public class Image extends com.pulumi.resources.CustomResource {
      * These secrets will not be considered when calculating diffs, even if they
      * are changed. Note: only applicable if the secret is present in both the old and the new state.
      * 
-     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
      * 
      */
     @Export(name="ignoreSecretsInDiffCalculation", refs={List.class,String.class}, tree="[0,1]")
@@ -951,7 +951,7 @@ public class Image extends com.pulumi.resources.CustomResource {
      * These secrets will not be considered when calculating diffs, even if they
      * are changed. Note: only applicable if the secret is present in both the old and the new state.
      * 
-     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
      * 
      */
     public Output<Optional<List<String>>> ignoreSecretsInDiffCalculation() {

--- a/sdk/java/src/main/java/com/pulumi/dockerbuild/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/dockerbuild/ImageArgs.java
@@ -291,6 +291,31 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * A list of secret names to ignore when calculating diffs.
+     * 
+     * These secrets will not be considered when calculating diffs, even if they
+     * are changed. Note: only applicable if the secret is present in both the old and the new state.
+     * 
+     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * 
+     */
+    @Import(name="ignoreSecretsInDiffCalculation")
+    private @Nullable Output<List<String>> ignoreSecretsInDiffCalculation;
+
+    /**
+     * @return A list of secret names to ignore when calculating diffs.
+     * 
+     * These secrets will not be considered when calculating diffs, even if they
+     * are changed. Note: only applicable if the secret is present in both the old and the new state.
+     * 
+     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * 
+     */
+    public Optional<Output<List<String>>> ignoreSecretsInDiffCalculation() {
+        return Optional.ofNullable(this.ignoreSecretsInDiffCalculation);
+    }
+
+    /**
      * Attach arbitrary key/value metadata to the image.
      * 
      * Equivalent to Docker&#39;s `--label` flag.
@@ -573,6 +598,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
         this.dockerfile = $.dockerfile;
         this.exec = $.exec;
         this.exports = $.exports;
+        this.ignoreSecretsInDiffCalculation = $.ignoreSecretsInDiffCalculation;
         this.labels = $.labels;
         this.load = $.load;
         this.network = $.network;
@@ -977,6 +1003,52 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder exports(ExportArgs... exports) {
             return exports(List.of(exports));
+        }
+
+        /**
+         * @param ignoreSecretsInDiffCalculation A list of secret names to ignore when calculating diffs.
+         * 
+         * These secrets will not be considered when calculating diffs, even if they
+         * are changed. Note: only applicable if the secret is present in both the old and the new state.
+         * 
+         * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder ignoreSecretsInDiffCalculation(@Nullable Output<List<String>> ignoreSecretsInDiffCalculation) {
+            $.ignoreSecretsInDiffCalculation = ignoreSecretsInDiffCalculation;
+            return this;
+        }
+
+        /**
+         * @param ignoreSecretsInDiffCalculation A list of secret names to ignore when calculating diffs.
+         * 
+         * These secrets will not be considered when calculating diffs, even if they
+         * are changed. Note: only applicable if the secret is present in both the old and the new state.
+         * 
+         * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder ignoreSecretsInDiffCalculation(List<String> ignoreSecretsInDiffCalculation) {
+            return ignoreSecretsInDiffCalculation(Output.of(ignoreSecretsInDiffCalculation));
+        }
+
+        /**
+         * @param ignoreSecretsInDiffCalculation A list of secret names to ignore when calculating diffs.
+         * 
+         * These secrets will not be considered when calculating diffs, even if they
+         * are changed. Note: only applicable if the secret is present in both the old and the new state.
+         * 
+         * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder ignoreSecretsInDiffCalculation(String... ignoreSecretsInDiffCalculation) {
+            return ignoreSecretsInDiffCalculation(List.of(ignoreSecretsInDiffCalculation));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/dockerbuild/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/dockerbuild/ImageArgs.java
@@ -296,7 +296,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
      * These secrets will not be considered when calculating diffs, even if they
      * are changed. Note: only applicable if the secret is present in both the old and the new state.
      * 
-     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
      * 
      */
     @Import(name="ignoreSecretsInDiffCalculation")
@@ -308,7 +308,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
      * These secrets will not be considered when calculating diffs, even if they
      * are changed. Note: only applicable if the secret is present in both the old and the new state.
      * 
-     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
      * 
      */
     public Optional<Output<List<String>>> ignoreSecretsInDiffCalculation() {
@@ -1011,7 +1011,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          * These secrets will not be considered when calculating diffs, even if they
          * are changed. Note: only applicable if the secret is present in both the old and the new state.
          * 
-         * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+         * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
          * 
          * @return builder
          * 
@@ -1027,7 +1027,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          * These secrets will not be considered when calculating diffs, even if they
          * are changed. Note: only applicable if the secret is present in both the old and the new state.
          * 
-         * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+         * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
          * 
          * @return builder
          * 
@@ -1042,7 +1042,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          * These secrets will not be considered when calculating diffs, even if they
          * are changed. Note: only applicable if the secret is present in both the old and the new state.
          * 
-         * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+         * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/image.ts
+++ b/sdk/nodejs/image.ts
@@ -608,6 +608,15 @@ export class Image extends pulumi.CustomResource {
      */
     declare public readonly exports: pulumi.Output<outputs.Export[] | undefined>;
     /**
+     * A list of secret names to ignore when calculating diffs.
+     *
+     * These secrets will not be considered when calculating diffs, even if they
+     * are changed. Note: only applicable if the secret is present in both the old and the new state.
+     *
+     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     */
+    declare public readonly ignoreSecretsInDiffCalculation: pulumi.Output<string[] | undefined>;
+    /**
      * Attach arbitrary key/value metadata to the image.
      *
      * Equivalent to Docker's `--label` flag.
@@ -742,6 +751,7 @@ export class Image extends pulumi.CustomResource {
             resourceInputs["dockerfile"] = args?.dockerfile;
             resourceInputs["exec"] = args?.exec;
             resourceInputs["exports"] = args?.exports;
+            resourceInputs["ignoreSecretsInDiffCalculation"] = args?.ignoreSecretsInDiffCalculation;
             resourceInputs["labels"] = args?.labels;
             resourceInputs["load"] = args?.load;
             resourceInputs["network"] = (args?.network) ?? "default";
@@ -770,6 +780,7 @@ export class Image extends pulumi.CustomResource {
             resourceInputs["dockerfile"] = undefined /*out*/;
             resourceInputs["exec"] = undefined /*out*/;
             resourceInputs["exports"] = undefined /*out*/;
+            resourceInputs["ignoreSecretsInDiffCalculation"] = undefined /*out*/;
             resourceInputs["labels"] = undefined /*out*/;
             resourceInputs["load"] = undefined /*out*/;
             resourceInputs["network"] = undefined /*out*/;
@@ -888,6 +899,15 @@ export interface ImageArgs {
      * Equivalent to Docker's `--output` flag.
      */
     exports?: pulumi.Input<pulumi.Input<inputs.ExportArgs>[] | undefined>;
+    /**
+     * A list of secret names to ignore when calculating diffs.
+     *
+     * These secrets will not be considered when calculating diffs, even if they
+     * are changed. Note: only applicable if the secret is present in both the old and the new state.
+     *
+     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     */
+    ignoreSecretsInDiffCalculation?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * Attach arbitrary key/value metadata to the image.
      *

--- a/sdk/nodejs/image.ts
+++ b/sdk/nodejs/image.ts
@@ -613,7 +613,7 @@ export class Image extends pulumi.CustomResource {
      * These secrets will not be considered when calculating diffs, even if they
      * are changed. Note: only applicable if the secret is present in both the old and the new state.
      *
-     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
      */
     declare public readonly ignoreSecretsInDiffCalculation: pulumi.Output<string[] | undefined>;
     /**
@@ -905,9 +905,9 @@ export interface ImageArgs {
      * These secrets will not be considered when calculating diffs, even if they
      * are changed. Note: only applicable if the secret is present in both the old and the new state.
      *
-     * This is useful when you want to avoid unnecessary rebuilds becayse of short-lived secrets change.
+     * This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
      */
-    ignoreSecretsInDiffCalculation?: pulumi.Input<pulumi.Input<string>[]>;
+    ignoreSecretsInDiffCalculation?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * Attach arbitrary key/value metadata to the image.
      *

--- a/sdk/python/pulumi_docker_build/image.py
+++ b/sdk/python/pulumi_docker_build/image.py
@@ -33,6 +33,7 @@ class ImageArgs:
                  dockerfile: pulumi.Input[Optional['DockerfileArgs']] = None,
                  exec_: pulumi.Input[Optional[_builtins.bool]] = None,
                  exports: pulumi.Input[Optional[Sequence[pulumi.Input['ExportArgs']]]] = None,
+                 ignore_secrets_in_diff_calculation: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  labels: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
                  load: pulumi.Input[Optional[_builtins.bool]] = None,
                  network: pulumi.Input[Optional['NetworkMode']] = None,
@@ -117,6 +118,12 @@ class ImageArgs:
                0.13 or later.
                
                Equivalent to Docker's `--output` flag.
+        :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] ignore_secrets_in_diff_calculation: A list of secret names to ignore when calculating diffs.
+               
+               These secrets will not be considered when calculating diffs, even if they
+               are changed. Note: only applicable if the secret is present in both the old and the new state.
+               
+               This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] labels: Attach arbitrary key/value metadata to the image.
                
                Equivalent to Docker's `--label` flag.
@@ -193,6 +200,8 @@ class ImageArgs:
             pulumi.set(__self__, "exec_", exec_)
         if exports is not None:
             pulumi.set(__self__, "exports", exports)
+        if ignore_secrets_in_diff_calculation is not None:
+            pulumi.set(__self__, "ignore_secrets_in_diff_calculation", ignore_secrets_in_diff_calculation)
         if labels is not None:
             pulumi.set(__self__, "labels", labels)
         if load is not None:
@@ -410,6 +419,23 @@ class ImageArgs:
         pulumi.set(self, "exports", value)
 
     @_builtins.property
+    @pulumi.getter(name="ignoreSecretsInDiffCalculation")
+    def ignore_secrets_in_diff_calculation(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
+        """
+        A list of secret names to ignore when calculating diffs.
+
+        These secrets will not be considered when calculating diffs, even if they
+        are changed. Note: only applicable if the secret is present in both the old and the new state.
+
+        This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
+        """
+        return pulumi.get(self, "ignore_secrets_in_diff_calculation")
+
+    @ignore_secrets_in_diff_calculation.setter
+    def ignore_secrets_in_diff_calculation(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
+        pulumi.set(self, "ignore_secrets_in_diff_calculation", value)
+
+    @_builtins.property
     @pulumi.getter
     def labels(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]:
         """
@@ -599,6 +625,7 @@ class Image(pulumi.CustomResource):
                  dockerfile: pulumi.Input[Optional[Union['DockerfileArgs', 'DockerfileArgsDict']]] = None,
                  exec_: pulumi.Input[Optional[_builtins.bool]] = None,
                  exports: pulumi.Input[Optional[Sequence[pulumi.Input[Union['ExportArgs', 'ExportArgsDict']]]]] = None,
+                 ignore_secrets_in_diff_calculation: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  labels: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
                  load: pulumi.Input[Optional[_builtins.bool]] = None,
                  network: pulumi.Input[Optional['NetworkMode']] = None,
@@ -987,6 +1014,12 @@ class Image(pulumi.CustomResource):
                0.13 or later.
                
                Equivalent to Docker's `--output` flag.
+        :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] ignore_secrets_in_diff_calculation: A list of secret names to ignore when calculating diffs.
+               
+               These secrets will not be considered when calculating diffs, even if they
+               are changed. Note: only applicable if the secret is present in both the old and the new state.
+               
+               This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] labels: Attach arbitrary key/value metadata to the image.
                
                Equivalent to Docker's `--label` flag.
@@ -1384,6 +1417,7 @@ class Image(pulumi.CustomResource):
                  dockerfile: pulumi.Input[Optional[Union['DockerfileArgs', 'DockerfileArgsDict']]] = None,
                  exec_: pulumi.Input[Optional[_builtins.bool]] = None,
                  exports: pulumi.Input[Optional[Sequence[pulumi.Input[Union['ExportArgs', 'ExportArgsDict']]]]] = None,
+                 ignore_secrets_in_diff_calculation: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  labels: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
                  load: pulumi.Input[Optional[_builtins.bool]] = None,
                  network: pulumi.Input[Optional['NetworkMode']] = None,
@@ -1417,6 +1451,7 @@ class Image(pulumi.CustomResource):
             __props__.__dict__["dockerfile"] = dockerfile
             __props__.__dict__["exec_"] = exec_
             __props__.__dict__["exports"] = exports
+            __props__.__dict__["ignore_secrets_in_diff_calculation"] = ignore_secrets_in_diff_calculation
             __props__.__dict__["labels"] = labels
             __props__.__dict__["load"] = load
             if network is None:
@@ -1470,6 +1505,7 @@ class Image(pulumi.CustomResource):
         __props__.__dict__["dockerfile"] = None
         __props__.__dict__["exec_"] = None
         __props__.__dict__["exports"] = None
+        __props__.__dict__["ignore_secrets_in_diff_calculation"] = None
         __props__.__dict__["labels"] = None
         __props__.__dict__["load"] = None
         __props__.__dict__["network"] = None
@@ -1643,6 +1679,19 @@ class Image(pulumi.CustomResource):
         Equivalent to Docker's `--output` flag.
         """
         return pulumi.get(self, "exports")
+
+    @_builtins.property
+    @pulumi.getter(name="ignoreSecretsInDiffCalculation")
+    def ignore_secrets_in_diff_calculation(self) -> pulumi.Output[Optional[Sequence[_builtins.str]]]:
+        """
+        A list of secret names to ignore when calculating diffs.
+
+        These secrets will not be considered when calculating diffs, even if they
+        are changed. Note: only applicable if the secret is present in both the old and the new state.
+
+        This is useful when you want to avoid unnecessary rebuilds caused by short-lived secrets that change on every run.
+        """
+        return pulumi.get(self, "ignore_secrets_in_diff_calculation")
 
     @_builtins.property
     @pulumi.getter


### PR DESCRIPTION
Argument `IgnoreSecretsInDiffCalculation` has been added to avoid unnecessary rebuilds in case short-lived secrets change. (https://github.com/pulumi/pulumi-docker-build/issues/678)