### PR TITLE
Include stderr in error message for exec mode failures

### DIFF
--- a/provider/internal/cli.go
+++ b/provider/internal/cli.go
@@ -398,7 +398,15 @@ func (c *cli) exec(ctx context.Context, args, extraEnv []string) error {
 	cmd.Stdin = c.In()
 	cmd.Env = append(runCmd.Env, extraEnv...) //nolint:gocritic // We are intentionally assigning from runCmd to cmd
 
-	return cmd.Run()
+	// Run the command and include stderr in error if it fails
+	if err := cmd.Run(); err != nil {
+		// Include stderr content in the error message if available
+		if c.err.Len() > 0 {
+			return fmt.Errorf("%w: %s", err, c.err.String())
+		}
+		return err
+	}
+	return nil
 }
 
 // attrcsv transforms key/values into a CSV: key1=value1,key2=value2,...


### PR DESCRIPTION
May make #656 easier to fix

When using exec: true mode, Docker buildx failures would only show the exit status (e.g., "exit status 125") without including the actual error message from Docker's stderr output.

This change modifies the exec() function to wrap the command error with the stderr content when available, making the actual Docker error immediately visible to users instead of being buried in logs.

Example of improved error message:
Before: "exit status 125"
After: "exit status 125: ERROR: failed to solve: failed to read dockerfile..."