### PR TITLE
Fix exec mode

### DIFF
--- a/provider/internal/cli.go
+++ b/provider/internal/cli.go
@@ -390,7 +390,7 @@ func (c *cli) exec(ctx context.Context, args, extraEnv []string) error {
 		return err
 	}
 	// Create a new command that inherits from ctx.
-	cmd := exec.CommandContext(ctx, //nolint:gosec // We take the first argument and binary from runCmd.
+	cmd := exec.CommandContext(ctx, //nolint:gosec // We take the arguments and binary from runCmd.
 		runCmd.Path, args...,
 	)
 	cmd.Stderr = c.Err()

--- a/provider/internal/cli.go
+++ b/provider/internal/cli.go
@@ -391,7 +391,7 @@ func (c *cli) exec(ctx context.Context, args, extraEnv []string) error {
 	}
 	// Create a new command that inherits from ctx.
 	cmd := exec.CommandContext(ctx, //nolint:gosec // We take the first argument and binary from runCmd.
-		runCmd.Path, append([]string{runCmd.Args[1]}, args...)...,
+		runCmd.Path, args...,
 	)
 	cmd.Stderr = c.Err()
 	cmd.Stdout = c.Out()


### PR DESCRIPTION
Fixes #656

Previously the CommandContext would receive the args with it prepended e.g. `/Users/<user>/.docker/cli-plugins/docker-buildx 127.0.0.1:53106` which caused `docker-buildx` to fail as arguments were out of order