### PR TITLE
Fix workflow failure by ensuring bin directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ bin/${PROVIDER}: $(shell find ./provider -name '*.go') go.mod
 	(cd provider && go build -o ../bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION_GENERIC}" $(PROJECT)/${PROVIDER_PATH}/cmd/$(PROVIDER))
 
 bin/pulumi-gen-${PACK}: # Required by CI
+	@mkdir -p bin
 	touch bin/pulumi-gen-${PACK}
 
 go.mod: $(shell find . -name '*.go')
@@ -257,6 +258,7 @@ AZURE_SIGNING_KEY_VAULT_URI ?=
 SKIP_SIGNING ?=
 
 bin/jsign-6.0.jar:
+	@mkdir -p bin
 	wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar --output-document=bin/jsign-6.0.jar
 
 sign-goreleaser-exe-amd64: GORELEASER_ARCH := amd64_v1


### PR DESCRIPTION
# **Note: This is a temporary fix until we get this to `ci-mgmt`**

## Summary
Fixes the GoReleaser workflow failure that started on Feb 6, 2026.

## Root Cause
Commit 491f7de deleted `bin/pulumi-language-python-exec`, which was the last file in the `bin/` directory. Since Git doesn't track empty directories, the `bin/` directory disappeared from the repository.

When GoReleaser runs the post-build hook `make sign-goreleaser-exe-amd64`, it attempts to download `jsign-6.0.jar` to `bin/jsign-6.0.jar`, but fails with:
```
bin/jsign-6.0.jar: No such file or directory
make: *** [Makefile:260: bin/jsign-6.0.jar] Error 1
```

## Changes
Added `@mkdir -p bin` to Makefile targets that write to the `bin/` directory:
- `bin/jsign-6.0.jar` target (line 260) - **Critical fix**
- `bin/pulumi-gen-${PACK}` target (line 185) - Defensive fix

This ensures the directory exists before attempting to create files in it.

Fixes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)