### PR TITLE
Restore .NET SDK target framework to net6.0

### DIFF
--- a/sdk/dotnet/Pulumi.DockerBuild.csproj
+++ b/sdk/dotnet/Pulumi.DockerBuild.csproj
@@ -11,7 +11,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <Version>0.1.0-alpha.0+dev</Version>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Restore the generated .NET SDK project target framework from `net8.0` to `net6.0`.
- Keep the change scoped to the framework bump introduced by #857.

## Testing
- `dotnet build sdk/dotnet/Pulumi.DockerBuild.csproj --source https://api.nuget.org/v3/index.json`

Note: a plain `dotnet build sdk/dotnet/Pulumi.DockerBuild.csproj` first failed during restore because user-level NuGet sources point at missing local worktree paths. The command above restricts restore to nuget.org; the SDK build also needs the transient `sdk/dotnet/version.txt` that the repo's `sdk/dotnet` generation target creates before building.