### PR TITLE
Hoist repeated literals to constants and annotate gosec test fixtures

### DIFF
--- a/docs/generate.go
+++ b/docs/generate.go
@@ -46,9 +46,11 @@ func main() {
 		yamlPath = filepath.Join(cwd, yamlPath)
 	}
 
+	//nolint:gosec // G703: mdPath is a build-time CLI argument, not user input.
 	if err := os.MkdirAll(mdPath, 0o750); err != nil {
 		panic(err)
 	}
+	//nolint:gosec // G703: mdPath is a build-time CLI argument, not user input.
 	fileInfo, err := os.Lstat(mdPath)
 	if err != nil || !fileInfo.IsDir() {
 		fmt.Fprintf(os.Stderr, "Expect markdown destination %q to be a directory\n", mdPath)

--- a/provider/internal/cache.go
+++ b/provider/internal/cache.go
@@ -175,7 +175,7 @@ func (c *CacheFromGitHubActions) String() string {
 	if c == nil {
 		return ""
 	}
-	parts := []string{"type=gha"}
+	parts := []string{typeGHA}
 	if c.Scope != "" {
 		parts = append(parts, "scope="+c.Scope)
 	}
@@ -470,11 +470,18 @@ func (c CacheFrom) validate(_ bool) (*controllerapi.CacheOptionsEntry, error) {
 	return pb, nil
 }
 
+const (
+	// cacheTypeGHA is the buildx cache backend type for GitHub Actions.
+	cacheTypeGHA = "gha"
+	// typeGHA is the buildx "type=gha" cache attribute.
+	typeGHA = "type=gha"
+)
+
 // isActive checks if the GitHub token is set in the cache entry.
 // If it is not a GHA cache entry, it will return true.
 // This is to maintain backwards compatibility with the old buildx behaviour.
 func isActive(ci *controllerapi.CacheOptionsEntry) bool {
-	if ci.Type != "gha" {
+	if ci.Type != cacheTypeGHA {
 		return true
 	}
 	return ci.Attrs["token"] != "" && (ci.Attrs["url"] != "" || ci.Attrs["url_v2"] != "")

--- a/provider/internal/cache_test.go
+++ b/provider/internal/cache_test.go
@@ -54,13 +54,13 @@ func TestCacheString(t *testing.T) {
 			want: "type=s3,bucket=bucket-foo,name=myname,endpoint_url=https://some.endpoint,blobs_prefix=blob-prefix,manifests_prefix=manifest-prefix,use_path_type=true,access_key_id=access-key-id,secret_access_key=secret-key,session_token=session",
 		},
 		{
-			name:  "gha",
+			name:  cacheTypeGHA,
 			given: CacheTo{GHA: &CacheToGitHubActions{}},
 			arrange: func(t *testing.T) {
 				t.Setenv("ACTIONS_CACHE_URL", "")
 				t.Setenv("ACTIONS_RUNTIME_TOKEN", "")
 			},
-			want: "type=gha",
+			want: typeGHA,
 		},
 		{
 			name: "gha-default-envs",
@@ -99,19 +99,19 @@ func TestCacheString(t *testing.T) {
 			want:  "type=local,dest=/foo/bar",
 		},
 		{
-			name:  "inline",
+			name:  inlineName,
 			given: CacheTo{Inline: &CacheToInline{}},
 			want:  "type=inline",
 		},
 		{
-			name:  "raw",
-			given: CacheTo{Raw: Raw("type=gha")},
-			want:  "type=gha",
+			name:  rawKey,
+			given: CacheTo{Raw: Raw(typeGHA)},
+			want:  typeGHA,
 		},
 		{
 			name: "compression",
 			given: CacheTo{Local: &CacheToLocal{
-				Dest: "/foo",
+				Dest: fooDest,
 				CacheWithCompression: CacheWithCompression{
 					Compression:      &gzip,
 					CompressionLevel: 100,
@@ -133,7 +133,7 @@ func TestCacheString(t *testing.T) {
 			name: "oci",
 			given: CacheTo{
 				Registry: &CacheToRegistry{
-					CacheFromRegistry: CacheFromRegistry{Ref: "docker.io/foo/bar:baz"},
+					CacheFromRegistry: CacheFromRegistry{Ref: dockerIOTaggedRef},
 					CacheWithOCI: CacheWithOCI{
 						OCI:           pulumi.BoolRef(true),
 						ImageManifest: pulumi.BoolRef(true),
@@ -145,7 +145,7 @@ func TestCacheString(t *testing.T) {
 		{
 			name: "disabled-to",
 			given: CacheTo{
-				Raw:      Raw("type=gha"),
+				Raw:      Raw(typeGHA),
 				Disabled: true,
 			},
 			want: "",

--- a/provider/internal/cli.go
+++ b/provider/internal/cli.go
@@ -46,6 +46,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
+// buildxName is the name of the buildx CLI plugin subcommand.
+const buildxName = "buildx"
+
 // cli wraps a DockerCLI instance with scoped auth credentials. It satisfies
 // the Cli interface so it can be used with Docker's cobra.Commands directly.
 //
@@ -237,7 +240,7 @@ func (c *cli) execBuild(ctx context.Context, b Build) (*client.SolveResponse, er
 	// build, like the digest.
 	metadata := filepath.Clean(filepath.Join(tmp, "metadata.json"))
 	args := []string{
-		"buildx",
+		buildxName,
 		"build",
 		"--progress", "plain",
 		"--metadata-file", metadata,

--- a/provider/internal/cli_test.go
+++ b/provider/internal/cli_test.go
@@ -33,7 +33,7 @@ func TestExec(t *testing.T) {
 	cli, err := wrap(h)
 	require.NoError(t, err)
 
-	err = cli.exec(t.Context(), []string{"buildx", "version"}, nil)
+	err = cli.exec(t.Context(), []string{buildxName, "version"}, nil)
 	assert.NoError(t, err)
 
 	out, err := io.ReadAll(cli.r)
@@ -50,27 +50,32 @@ func TestWrappedAuth(t *testing.T) {
 
 	h := &host{
 		auths: map[string]types.AuthConfig{
+			//nolint:gosec // G101: test fixture, not a real credential.
 			ecr: {
 				Username:      "host-aws-user",
 				Password:      "host-aws-password",
 				ServerAddress: ecr,
 			},
-			"https://misc": { // Legacy config includes http/https scheme.
+			// Legacy config includes http/https scheme.
+			//nolint:gosec // G101: test fixture, not a real credential.
+			"https://misc": {
 				Username:      "host-misc-user",
 				Password:      "host-misc-password",
-				ServerAddress: "misc",
+				ServerAddress: miscName,
 			},
 		},
 	}
 
 	registries := []Registry{
+		//nolint:gosec // G101: test fixture, not a real credential.
 		{
-			Address:  "1234.dkr.ecr.us-west-2.amazonaws.com",
+			Address:  awsECRAddress,
 			Username: "resource-aws-user",
 			Password: "resource-aws-password",
 		},
+		//nolint:gosec // G101: test fixture, not a real credential.
 		{
-			Address:  "docker.io",
+			Address:  dockerIO,
 			Username: "resource-dockerhub-user",
 			Password: "resource-dockerhub-password",
 		},
@@ -83,20 +88,23 @@ func TestWrappedAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := map[string]types.AuthConfig{
-		"1234.dkr.ecr.us-west-2.amazonaws.com": {
+		//nolint:gosec // G101: test fixture, not a real credential.
+		awsECRAddress: {
 			Username:      "resource-aws-user",
 			Password:      "resource-aws-password",
-			ServerAddress: "1234.dkr.ecr.us-west-2.amazonaws.com",
+			ServerAddress: awsECRAddress,
 		},
+		//nolint:gosec // G101: test fixture, not a real credential.
 		config.DockerRegistryAuth: {
 			Username:      "resource-dockerhub-user",
 			Password:      "resource-dockerhub-password",
 			ServerAddress: config.DockerRegistryDNS,
 		},
-		"misc": {
+		//nolint:gosec // G101: test fixture, not a real credential.
+		miscName: {
 			Username:      "host-misc-user",
 			Password:      "host-misc-password",
-			ServerAddress: "misc",
+			ServerAddress: miscName,
 		},
 	}
 	assert.Equal(t, expected, cli.auths)

--- a/provider/internal/client.go
+++ b/provider/internal/client.go
@@ -224,9 +224,11 @@ func (c *cli) Build(
 		return nil, err
 	}
 
+	// buildx's default build target name (unrelated to NetworkMode.Default).
+	const defaultTarget = "default"
 	target := opts.Target
 	if target == "" {
-		target = "default"
+		target = defaultTarget
 	}
 	payload := map[string]buildx.Options{
 		target: {

--- a/provider/internal/client_test.go
+++ b/provider/internal/client_test.go
@@ -43,7 +43,7 @@ func TestAuth(t *testing.T) {
 		user = u
 	}
 	password := os.Getenv("DOCKER_HUB_PASSWORD")
-	address := "docker.io"
+	address := dockerIO
 
 	cli := testcli(t, true, Registry{
 		Address:  address,
@@ -90,7 +90,7 @@ func TestBuild(t *testing.T) {
 	tmpdir := t.TempDir()
 	Max := Max
 
-	exampleContext := &BuildContext{Context: Context{Location: "../../examples/app"}}
+	exampleContext := &BuildContext{Context: Context{Location: exampleAppContext}}
 
 	tests := []struct {
 		name string
@@ -118,7 +118,7 @@ func TestBuild(t *testing.T) {
 				Push:    true,
 			},
 			auths: []Registry{{
-				Address:  "docker.io",
+				Address:  dockerIO,
 				Username: "pulumibot",
 				Password: os.Getenv("DOCKER_HUB_PASSWORD"),
 			}},
@@ -169,7 +169,7 @@ func TestBuild(t *testing.T) {
 				Dockerfile: &Dockerfile{
 					Location: "../../examples/app/Dockerfile.sshMount",
 				},
-				SSH: []SSH{{ID: "default"}},
+				SSH: []SSH{{ID: defaultSSHID}},
 			},
 		},
 		{
@@ -180,7 +180,7 @@ func TestBuild(t *testing.T) {
 					Location: "../../examples/app/Dockerfile.secrets",
 				},
 				Secrets: map[string]string{
-					"password": "hunter2",
+					passwordKey: "hunter2",
 				},
 				NoCache: true,
 			},
@@ -190,7 +190,7 @@ func TestBuild(t *testing.T) {
 			args: ImageArgs{
 				Context: exampleContext,
 				Labels: map[string]string{
-					"description": "foo",
+					"description": fooName,
 				},
 			},
 		},
@@ -209,7 +209,7 @@ func TestBuild(t *testing.T) {
 			args: ImageArgs{
 				Context: &BuildContext{
 					Context: Context{
-						Location: "../../examples/app",
+						Location: exampleAppContext,
 					},
 					Named: NamedContexts{
 						"golang:latest": Context{
@@ -249,7 +249,7 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
-			name: "inline",
+			name: inlineName,
 			args: ImageArgs{
 				Context: exampleContext,
 				Dockerfile: &Dockerfile{
@@ -333,7 +333,7 @@ func TestNormalizeReference(t *testing.T) {
 		wantErr string
 	}{
 		{
-			ref:  "foo",
+			ref:  fooName,
 			want: "docker.io/library/foo:latest",
 		},
 		{
@@ -376,7 +376,7 @@ func TestBuildError(t *testing.T) {
 		),
 	)
 
-	exampleContext := &BuildContext{Context: Context{Location: "../../examples/app"}}
+	exampleContext := &BuildContext{Context: Context{Location: exampleAppContext}}
 
 	args := ImageArgs{
 		Context: exampleContext,
@@ -410,7 +410,7 @@ func TestBuildError(t *testing.T) {
 func TestBuildExecError(t *testing.T) {
 	t.Parallel()
 
-	exampleContext := &BuildContext{Context: Context{Location: "../../examples/app"}}
+	exampleContext := &BuildContext{Context: Context{Location: exampleAppContext}}
 
 	args := ImageArgs{
 		Context: exampleContext,

--- a/provider/internal/constants_test.go
+++ b/provider/internal/constants_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// Shared string literals used across the package's tests. Hoisted to
+// constants to satisfy goconst and keep fixtures consistent.
+const (
+	fooName = "foo"
+	barName = "bar"
+
+	dockerIO          = "docker.io"
+	dockerIORef       = "docker.io/foo/bar"
+	dockerIOTaggedRef = "docker.io/foo/bar:baz"
+
+	fromScratch = "FROM scratch"
+	inlineName  = "inline"
+	fooDest     = "/foo"
+
+	contextKey  = "context"
+	locationKey = "location"
+	exportsKey  = "exports"
+	addressKey  = "address"
+	knownKey    = "known"
+
+	notReal = "not-real"
+	oldBar  = "old_bar"
+	newBar  = "new_bar"
+
+	fooDockerfilePath = "./foo/Dockerfile"
+	dockerignoreName  = ".dockerignore"
+	customIgnore      = "customignore"
+	exampleAppContext = "../../examples/app"
+
+	miscName      = "misc"
+	awsECRAddress = "1234.dkr.ecr.us-west-2.amazonaws.com"
+
+	rawKey      = "raw"
+	usernameKey = "username"
+	passwordKey = "password" //nolint:gosec // G101: property-name key, not a real credential.
+
+	rootIgnore             = "rootignore"
+	unknownInstructionRUNN = "unknown instruction: RUNN"
+	typeTar                = "type=tar"
+	testdataNoop           = "testdata/noop"
+
+	// defaultSSHID is buildkit's default SSH agent forward ID (unrelated to
+	// NetworkMode.Default).
+	defaultSSHID = "default"
+
+	testCacheURL     = "test-cache-url"
+	testRuntimeToken = "test-runtime-token" //nolint:gosec // G101: test fixture, not a real credential.
+	testResultsURL   = "test-results-url"
+)

--- a/provider/internal/context_test.go
+++ b/provider/internal/context_test.go
@@ -336,40 +336,40 @@ func TestDockerIgnore(t *testing.T) {
 	}{
 		{
 			name:       "Dockerfile with root dockerignore",
-			dockerfile: "./foo/Dockerfile",
+			dockerfile: fooDockerfilePath,
 			fs: map[string]string{
-				".dockerignore": "rootignore",
+				dockerignoreName: rootIgnore,
 			},
-			want: []string{"rootignore"},
+			want: []string{rootIgnore},
 		},
 		{
 			name:       "Dockerfile with root dockerignore and custom dockerignore",
-			dockerfile: "./foo/Dockerfile",
+			dockerfile: fooDockerfilePath,
 			fs: map[string]string{
-				"foo/Dockerfile.dockerignore": "customignore",
-				".dockerignore":               "rootignore",
+				"foo/Dockerfile.dockerignore": customIgnore,
+				dockerignoreName:              rootIgnore,
 			},
-			want: []string{"customignore"},
+			want: []string{customIgnore},
 		},
 		{
 			name:       "Dockerfile with root dockerignore and relative context",
-			dockerfile: "./foo/Dockerfile",
+			dockerfile: fooDockerfilePath,
 			context:    "../",
 			fs: map[string]string{
-				"../.dockerignore": "rootignore",
+				"../.dockerignore": rootIgnore,
 			},
-			want: []string{"rootignore"},
+			want: []string{rootIgnore},
 		},
 		{
 			name:       "Dockerfile without root dockerignore",
-			dockerfile: "./foo/Dockerfile",
+			dockerfile: fooDockerfilePath,
 			want:       nil,
 		},
 		{
 			name:       "Dockerfile with invalid root dockerignore",
-			dockerfile: "./foo/Dockerfile",
+			dockerfile: fooDockerfilePath,
 			fs: map[string]string{
-				".dockerignore": strings.Repeat("*", bufio.MaxScanTokenSize),
+				dockerignoreName: strings.Repeat("*", bufio.MaxScanTokenSize),
 			},
 			wantErr: bufio.ErrTooLong,
 		},
@@ -382,26 +382,26 @@ func TestDockerIgnore(t *testing.T) {
 			name:       "custom.Dockerfile with custom dockerignore and without root dockerignore",
 			dockerfile: "./foo/custom.Dockerfile",
 			fs: map[string]string{
-				"foo/custom.Dockerfile.dockerignore": "customignore",
+				"foo/custom.Dockerfile.dockerignore": customIgnore,
 			},
-			want: []string{"customignore"},
+			want: []string{customIgnore},
 		},
 		{
 			name:       "custom.Dockerfile with custom dockerignore and with root dockerignore",
 			dockerfile: "foo/custom.Dockerfile",
 			fs: map[string]string{
-				"foo/custom.Dockerfile.dockerignore": "customignore",
-				".dockerignore":                      "rootignore",
+				"foo/custom.Dockerfile.dockerignore": customIgnore,
+				dockerignoreName:                     rootIgnore,
 			},
-			want: []string{"customignore"},
+			want: []string{customIgnore},
 		},
 		{
 			name:       "custom.Dockerfile without custom dockerignore and with root dockerignore",
 			dockerfile: "foo/custom.Dockerfile",
 			fs: map[string]string{
-				".dockerignore": "rootignore",
+				dockerignoreName: rootIgnore,
 			},
-			want: []string{"rootignore"},
+			want: []string{rootIgnore},
 		},
 	}
 

--- a/provider/internal/dockerfile_test.go
+++ b/provider/internal/dockerfile_test.go
@@ -48,14 +48,14 @@ func TestValidateDockerfile(t *testing.T) {
 			d: Dockerfile{
 				Location: "testdata/Dockerfile.invalid",
 			},
-			wantErr: "unknown instruction: RUNN",
+			wantErr: unknownInstructionRUNN,
 		},
 		{
 			name: "invalid syntax inline",
 			d: Dockerfile{
 				Inline: "RUNN it",
 			},
-			wantErr: "unknown instruction: RUNN",
+			wantErr: unknownInstructionRUNN,
 		},
 		{
 			name: "invalid syntax inline with default syntax directive",
@@ -63,12 +63,12 @@ func TestValidateDockerfile(t *testing.T) {
 				Inline: `# syntax=docker/dockerfile:1
 				RUNN it`,
 			},
-			wantErr: "unknown instruction: RUNN",
+			wantErr: unknownInstructionRUNN,
 		},
 		{
 			name: "valid syntax inline",
 			d: Dockerfile{
-				Inline: "FROM scratch",
+				Inline: fromScratch,
 			},
 		},
 		{
@@ -99,7 +99,7 @@ COPY --parents ./package.json ./package-lock.json ./apps/*/package.json ./packag
 		},
 		{
 			name:    "over-specified",
-			d:       Dockerfile{Location: ".", Inline: "FROM scratch"},
+			d:       Dockerfile{Location: ".", Inline: fromScratch},
 			wantErr: `only specify "file" or "inline", not both`,
 		},
 	}

--- a/provider/internal/export.go
+++ b/provider/internal/export.go
@@ -29,7 +29,21 @@ import (
 )
 
 const (
-	trueLiteral = "true"
+	trueLiteral  = "true"
+	falseLiteral = "false"
+
+	// exportTypeImage is the buildkit exporter type for images.
+	exportTypeImage = "image"
+	// registryLiteral is the "registry" export type / property name.
+	registryLiteral = "registry"
+	// typeRegistry is the buildkit "type=registry" exporter shorthand.
+	typeRegistry = "type=registry"
+
+	// Attribute and property keys shared across outputs and diffs.
+	pushKey    = "push"
+	tagsKey    = "tags"
+	tagKey     = "tag"
+	sourcesKey = "sources"
 )
 
 var (
@@ -118,7 +132,7 @@ func (e Export) pushed() bool {
 		if err != nil {
 			return false
 		}
-		return exp[0].Attrs["push"] == trueLiteral
+		return exp[0].Attrs[pushKey] == trueLiteral
 	}
 	if e.Registry != nil {
 		return e.Registry.Push == nil || *e.Registry.Push
@@ -183,10 +197,10 @@ func parseExports(inp []string) ([]*controllerapi.ExportEntry, error) {
 			return nil, errors.New("type is required for output")
 		}
 
-		if out.Type == "registry" {
+		if out.Type == registryLiteral {
 			out.Type = client.ExporterImage
-			if _, ok := out.Attrs["push"]; !ok {
-				out.Attrs["push"] = trueLiteral
+			if _, ok := out.Attrs[pushKey]; !ok {
+				out.Attrs[pushKey] = trueLiteral
 			}
 		}
 
@@ -220,8 +234,8 @@ func (e Export) validate(preview bool, tags []string) (*controllerapi.ExportEntr
 	}
 
 	// Don't perform registry pushes during previews.
-	if exp.Type == "image" {
-		exp.Attrs["push"] = "false"
+	if exp.Type == exportTypeImage {
+		exp.Attrs[pushKey] = falseLiteral
 	}
 	return exp, nil
 }
@@ -409,7 +423,7 @@ func (e *ExportRegistry) String() string {
 	if e == nil {
 		return ""
 	}
-	return strings.Replace(e.ExportImage.String(), "type=image", "type=registry", 1)
+	return strings.Replace(e.ExportImage.String(), "type=image", typeRegistry, 1)
 }
 
 // ExportLocal writes the final image to disk.
@@ -570,5 +584,5 @@ func (e *ExportWithAnnotations) Annotate(a infer.Annotator) {
 func isRegistryPush(export *controllerapi.ExportEntry) bool {
 	// "type=registry" is shorthand for "type=image,push=true" so we only need
 	// to check "image" types.
-	return export.Type == "image" && export.Attrs["push"] == "true"
+	return export.Type == exportTypeImage && export.Attrs[pushKey] == trueLiteral
 }

--- a/provider/internal/export_test.go
+++ b/provider/internal/export_test.go
@@ -39,26 +39,26 @@ func TestValidateExport(t *testing.T) {
 		{
 			name:      "raw - no push on preview",
 			preview:   true,
-			e:         Export{Raw: "type=registry"},
-			givenTags: []string{"docker.io/foo/bar"},
+			e:         Export{Raw: typeRegistry},
+			givenTags: []string{dockerIORef},
 			wantExp: &controllerapi.ExportEntry{
-				Type:  "image",
-				Attrs: map[string]string{"push": "false"},
+				Type:  exportTypeImage,
+				Attrs: map[string]string{pushKey: falseLiteral},
 			},
 		},
 		{
 			name:    "raw - push requires tags",
-			e:       Export{Raw: "type=registry"},
+			e:       Export{Raw: typeRegistry},
 			wantErr: "tag or export name is needed",
 		},
 		{
 			name:      "registry - no push on preview",
 			preview:   true,
 			e:         Export{Registry: &ExportRegistry{}},
-			givenTags: []string{"docker.io/foo/bar"},
+			givenTags: []string{dockerIORef},
 			wantExp: &controllerapi.ExportEntry{
-				Type:  "image",
-				Attrs: map[string]string{"push": "false"},
+				Type:  exportTypeImage,
+				Attrs: map[string]string{pushKey: falseLiteral},
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func TestValidateExport(t *testing.T) {
 		},
 		{
 			name:    "over-specified",
-			e:       Export{Raw: "type=registry", Registry: &ExportRegistry{}},
+			e:       Export{Raw: typeRegistry, Registry: &ExportRegistry{}},
 			wantErr: "specify one export type",
 		},
 	}
@@ -100,7 +100,7 @@ func TestExportString(t *testing.T) {
 	}{
 		{
 			name:  "tar",
-			given: Export{Tar: &ExportTar{ExportLocal: ExportLocal{Dest: "/foo"}}},
+			given: Export{Tar: &ExportTar{ExportLocal: ExportLocal{Dest: fooDest}}},
 			want:  "type=tar,dest=/foo",
 		},
 		{
@@ -131,7 +131,7 @@ func TestExportString(t *testing.T) {
 			want: "type=registry,push=false",
 		},
 		{
-			name: "image",
+			name: exportTypeImage,
 			given: Export{
 				Image: &ExportImage{
 					Push:               pulumi.BoolRef(true),
@@ -149,7 +149,7 @@ func TestExportString(t *testing.T) {
 			given: Export{OCI: &ExportOCI{
 				ExportDocker: ExportDocker{
 					ExportWithNames: ExportWithNames{
-						Names: []string{"foo", "bar"},
+						Names: []string{fooName, barName},
 					},
 				},
 			}},
@@ -160,15 +160,15 @@ func TestExportString(t *testing.T) {
 			given: Export{Docker: &ExportDocker{
 				ExportWithAnnotations: ExportWithAnnotations{
 					Annotations: map[string]string{
-						"foo": "bar",
-						"boo": "baz",
+						fooName: barName,
+						"boo":   "baz",
 					},
 				},
 			}},
 			want: "type=docker,annotation.boo=baz,annotation.foo=bar",
 		},
 		{
-			name:  "raw",
+			name:  rawKey,
 			given: Export{Raw: Raw("type=docker")},
 			want:  "type=docker",
 		},
@@ -203,7 +203,7 @@ func TestExportPushed(t *testing.T) {
 	}{
 		{
 			name: "raw registry",
-			e:    Export{Raw: "type=registry"},
+			e:    Export{Raw: typeRegistry},
 			want: true,
 		},
 		{

--- a/provider/internal/image.go
+++ b/provider/internal/image.go
@@ -432,7 +432,7 @@ func (ia *ImageArgs) normalize(preview bool) ImageArgs {
 
 	// Handle --push/--load shorthand.
 	if normalized.Push {
-		normalized.Exports = append(normalized.Exports, Export{Raw: "type=registry"})
+		normalized.Exports = append(normalized.Exports, Export{Raw: typeRegistry})
 	}
 	if normalized.Load {
 		normalized.Exports = append(normalized.Exports, Export{Raw: "type=docker"})
@@ -544,7 +544,7 @@ func (ia *ImageArgs) validate(supportsMultipleExports, preview bool) (controller
 				multierr,
 				newCheckFailure(
 					errors.New("simultaneous push and load requires a v0.13 buildkit daemon or newer"),
-					"push",
+					pushKey,
 				),
 			)
 		}
@@ -979,7 +979,7 @@ func (*Image) Diff(
 		diff["pull"] = update
 	}
 	if !reflect.DeepEqual(olds.Push, news.Push) {
-		diff["push"] = update
+		diff[pushKey] = update
 	}
 	oldSecretsCopy := maps.Clone(olds.Secrets)
 	newsSecretsCopy := maps.Clone(news.Secrets)
@@ -998,7 +998,7 @@ func (*Image) Diff(
 		diff["ssh"] = update
 	}
 	if !reflect.DeepEqual(olds.Tags, news.Tags) {
-		diff["tags"] = update
+		diff[tagsKey] = update
 	}
 	if !reflect.DeepEqual(olds.Target, news.Target) {
 		diff["target"] = update

--- a/provider/internal/image_test.go
+++ b/provider/internal/image_test.go
@@ -87,8 +87,8 @@ func TestImageLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"push": property.New(false),
-						"tags": property.New(
+						pushKey: property.New(false),
+						tagsKey: property.New(
 							[]property.Value{
 								property.New("docker.io/pulumibot/buildkit-e2e"),
 								property.New("docker.io/pulumibot/buildkit-e2e:main"),
@@ -97,19 +97,19 @@ func TestImageLifecycle(t *testing.T) {
 						"platforms": property.New(
 							[]property.Value{
 								property.New("linux/arm64"),
-								property.New("linux/amd64"),
+								property.New(platformLinuxAMD64),
 							},
 						),
-						"context": property.New(map[string]property.Value{
-							"location": property.New("testdata/noop"),
+						contextKey: property.New(map[string]property.Value{
+							locationKey: property.New(testdataNoop),
 						}),
 						"dockerfile": property.New(map[string]property.Value{
-							"location": property.New("testdata/noop/Dockerfile"),
+							locationKey: property.New("testdata/noop/Dockerfile"),
 						}),
-						"exports": property.New(
+						exportsKey: property.New(
 							[]property.Value{
 								property.New(map[string]property.Value{
-									"raw": property.New("type=registry"),
+									rawKey: property.New(typeRegistry),
 								},
 								),
 							},
@@ -117,9 +117,9 @@ func TestImageLifecycle(t *testing.T) {
 						"registries": property.New(
 							[]property.Value{
 								property.New(map[string]property.Value{
-									"address":  property.New("fakeaddress"),
-									"username": property.New("fakeuser"),
-									"password": property.New("password").WithSecret(true),
+									addressKey:  property.New("fakeaddress"),
+									usernameKey: property.New("fakeuser"),
+									passwordKey: property.New(passwordKey).WithSecret(true),
 								}),
 							},
 						),
@@ -133,15 +133,15 @@ func TestImageLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"push": property.New(false),
-						"tags": property.New([]property.Value{}),
-						"context": property.New(map[string]property.Value{
-							"location": property.New("testdata/noop"),
+						pushKey: property.New(false),
+						tagsKey: property.New([]property.Value{}),
+						contextKey: property.New(map[string]property.Value{
+							locationKey: property.New(testdataNoop),
 						}),
-						"exports": property.New(
+						exportsKey: property.New(
 							[]property.Value{
 								property.New(map[string]property.Value{
-									"raw": property.New("type=registry"),
+									rawKey: property.New(typeRegistry),
 								}),
 							},
 						),
@@ -162,14 +162,14 @@ func TestImageLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"push": property.New(false),
-						"tags": property.New(
+						pushKey: property.New(false),
+						tagsKey: property.New(
 							[]property.Value{property.New("invalid-exports")},
 						),
-						"exports": property.New(
+						exportsKey: property.New(
 							[]property.Value{
 								property.New(map[string]property.Value{
-									"raw": property.New("type="),
+									rawKey: property.New("type="),
 								}),
 							},
 						),
@@ -195,12 +195,12 @@ func TestImageLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"push": property.New(false),
-						"tags": property.New(
-							[]property.Value{property.New("foo")},
+						pushKey: property.New(false),
+						tagsKey: property.New(
+							[]property.Value{property.New(fooName)},
 						),
-						"context": property.New(map[string]property.Value{
-							"location": property.New("testdata/noop"),
+						contextKey: property.New(map[string]property.Value{
+							locationKey: property.New(testdataNoop),
 						}),
 					}),
 					ExpectFailure: true,
@@ -222,12 +222,12 @@ func TestImageLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"push": property.New(false),
-						"tags": property.New(
-							[]property.Value{property.New("foo")},
+						pushKey: property.New(false),
+						tagsKey: property.New(
+							[]property.Value{property.New(fooName)},
 						),
-						"context": property.New(map[string]property.Value{
-							"location": property.New("testdata/noop"),
+						contextKey: property.New(map[string]property.Value{
+							locationKey: property.New(testdataNoop),
 						}),
 					}),
 					ExpectFailure: true,
@@ -255,21 +255,21 @@ func TestImageLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"push": property.New(false),
-						"tags": property.New(
+						pushKey: property.New(false),
+						tagsKey: property.New(
 							[]property.Value{
 								property.New("default-dockerfile"),
 							},
 						),
-						"context": property.New(map[string]property.Value{
-							"location": property.New("testdata/noop"),
+						contextKey: property.New(map[string]property.Value{
+							locationKey: property.New(testdataNoop),
 						}),
 					}),
 					Hook: func(_, output property.Map) {
 						dockerfile := output.Get("dockerfile")
 						require.NotNil(t, dockerfile)
 						require.True(t, dockerfile.IsMap())
-						location := dockerfile.AsMap().Get("location")
+						location := dockerfile.AsMap().Get(locationKey)
 						require.True(t, location.IsString())
 						assert.Equal(t, "testdata/noop/Dockerfile", location.AsString())
 					},
@@ -297,22 +297,22 @@ func TestImageLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"push": property.New(false),
-						"tags": property.New(
+						pushKey: property.New(false),
+						tagsKey: property.New(
 							[]property.Value{
 								property.New("inline-dockerfile"),
 							},
 						),
 						"buildOnPreview": property.New(true),
 						"dockerfile": property.New(map[string]property.Value{
-							"inline": property.New("FROM alpine:latest"),
+							inlineName: property.New("FROM alpine:latest"),
 						}),
 					}),
 					Hook: func(_, output property.Map) {
-						context := output.Get("context")
+						context := output.Get(contextKey)
 						require.NotNil(t, context)
 						require.True(t, context.IsMap())
-						location := context.AsMap().Get("location")
+						location := context.AsMap().Get(locationKey)
 						require.True(t, location.IsString())
 						assert.Equal(t, ".", location.AsString())
 					},
@@ -392,7 +392,7 @@ func TestRead(t *testing.T) {
 		ID: "my-image",
 		State: ImageState{
 			ImageArgs: ImageArgs{
-				Exports: []Export{{Raw: "type=registry"}},
+				Exports: []Export{{Raw: typeRegistry}},
 				Tags:    []string{tag},
 			},
 			Digest: digest,
@@ -412,7 +412,7 @@ func TestImageDiff(t *testing.T) {
 	require.NoError(t, err)
 	baseArgs := ImageArgs{
 		Context:    &BuildContext{Context: Context{Location: emptyDir}},
-		Dockerfile: &Dockerfile{Location: "testdata/noop"},
+		Dockerfile: &Dockerfile{Location: testdataNoop},
 		Tags:       []string{},
 	}
 	baseState := ImageState{
@@ -437,16 +437,16 @@ func TestImageDiff(t *testing.T) {
 			name: "no diff if registry password changes",
 			state: func(_ *testing.T, s ImageState) ImageState {
 				s.Registries = []Registry{{
-					Address:  "foo",
-					Username: "foo",
-					Password: "foo",
+					Address:  fooName,
+					Username: fooName,
+					Password: fooName,
 				}}
 				return s
 			},
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
 				a.Registries = []Registry{{
-					Address:  "foo",
-					Username: "foo",
+					Address:  fooName,
+					Username: fooName,
 					Password: "DIFFERENT PASSWORD",
 				}}
 				return a
@@ -504,17 +504,17 @@ func TestImageDiff(t *testing.T) {
 			name: "diff if registry user changes",
 			state: func(_ *testing.T, s ImageState) ImageState {
 				s.Registries = []Registry{{
-					Address:  "foo",
-					Username: "foo",
-					Password: "foo",
+					Address:  fooName,
+					Username: fooName,
+					Password: fooName,
 				}}
 				return s
 			},
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
 				a.Registries = []Registry{{
 					Address:  "DIFFERENT USER",
-					Username: "foo",
-					Password: "foo",
+					Username: fooName,
+					Password: fooName,
 				}}
 				return a
 			},
@@ -525,7 +525,7 @@ func TestImageDiff(t *testing.T) {
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
 				a.BuildArgs = map[string]string{
-					"foo": "bar",
+					fooName: barName,
 				}
 				return a
 			},
@@ -582,7 +582,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if ssh changes",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, ia ImageArgs) ImageArgs {
-				ia.SSH = []SSH{{ID: "default"}}
+				ia.SSH = []SSH{{ID: defaultSSHID}}
 				return ia
 			},
 			wantChanges: true,
@@ -627,7 +627,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if named context changes",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Context = &BuildContext{Named: NamedContexts{"foo": Context{Location: "bar"}}}
+				a.Context = &BuildContext{Named: NamedContexts{fooName: Context{Location: barName}}}
 				return a
 			},
 			wantChanges: true,
@@ -654,7 +654,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if dockerfile inline changes",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Dockerfile = &Dockerfile{Inline: "FROM scratch"}
+				a.Dockerfile = &Dockerfile{Inline: fromScratch}
 				return a
 			},
 			wantChanges: true,
@@ -663,7 +663,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if platforms change",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Platforms = []Platform{"linux/amd64"}
+				a.Platforms = []Platform{platformLinuxAMD64}
 				return a
 			},
 			wantChanges: true,
@@ -681,7 +681,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if builder changes",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Builder = &BuilderConfig{Name: "foo"}
+				a.Builder = &BuilderConfig{Name: fooName}
 				return a
 			},
 			wantChanges: true,
@@ -690,7 +690,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if tags change",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Tags = []string{"foo"}
+				a.Tags = []string{fooName}
 				return a
 			},
 			wantChanges: true,
@@ -699,7 +699,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if exports change",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Exports = []Export{{Raw: "foo"}}
+				a.Exports = []Export{{Raw: fooName}}
 				return a
 			},
 			wantChanges: true,
@@ -708,7 +708,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if target changes",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Target = "foo"
+				a.Target = fooName
 				return a
 			},
 			wantChanges: true,
@@ -735,7 +735,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if labels change",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Labels = map[string]string{"foo": "bar"}
+				a.Labels = map[string]string{fooName: barName}
 				return a
 			},
 			wantChanges: true,
@@ -744,7 +744,7 @@ func TestImageDiff(t *testing.T) {
 			name:  "diff if secrets change",
 			state: func(*testing.T, ImageState) ImageState { return baseState },
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Secrets = map[string]string{"foo": "bar"}
+				a.Secrets = map[string]string{fooName: barName}
 				return a
 			},
 			wantChanges: true,
@@ -752,13 +752,13 @@ func TestImageDiff(t *testing.T) {
 		{
 			name: "diff if secrets change but ignoreSecretsInDiffCalculation is set",
 			state: func(_ *testing.T, s ImageState) ImageState {
-				s.Secrets = map[string]string{"foo": "old_bar"}
-				s.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				s.Secrets = map[string]string{fooName: oldBar}
+				s.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return s
 			},
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Secrets = map[string]string{"foo": "new_bar"}
-				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				a.Secrets = map[string]string{fooName: newBar}
+				a.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return a
 			},
 			wantChanges: false,
@@ -766,12 +766,12 @@ func TestImageDiff(t *testing.T) {
 		{
 			name: "diff if secrets change but ignoreSecretsInDiffCalculation is set for another secret",
 			state: func(_ *testing.T, s ImageState) ImageState {
-				s.Secrets = map[string]string{"foo": "old_bar"}
+				s.Secrets = map[string]string{fooName: oldBar}
 				s.IgnoreSecretsInDiffCalculation = []string{"not_foo"}
 				return s
 			},
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Secrets = map[string]string{"foo": "new_bar"}
+				a.Secrets = map[string]string{fooName: newBar}
 				a.IgnoreSecretsInDiffCalculation = []string{"not_foo"}
 				return a
 			},
@@ -780,12 +780,12 @@ func TestImageDiff(t *testing.T) {
 		{
 			name: "diff if secrets change but ignoreSecretsInDiffCalculation is set and secret is added",
 			state: func(_ *testing.T, s ImageState) ImageState {
-				s.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				s.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return s
 			},
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Secrets = map[string]string{"foo": "bar"}
-				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				a.Secrets = map[string]string{fooName: barName}
+				a.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return a
 			},
 			wantChanges: true,
@@ -793,12 +793,12 @@ func TestImageDiff(t *testing.T) {
 		{
 			name: "diff if secrets change but ignoreSecretsInDiffCalculation is set and secret is removed",
 			state: func(_ *testing.T, s ImageState) ImageState {
-				s.Secrets = map[string]string{"foo": "bar"}
-				s.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				s.Secrets = map[string]string{fooName: barName}
+				s.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return s
 			},
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				a.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return a
 			},
 			wantChanges: true,
@@ -806,13 +806,13 @@ func TestImageDiff(t *testing.T) {
 		{
 			name: "diff if an ignored secret and a non-ignored secret both change",
 			state: func(_ *testing.T, s ImageState) ImageState {
-				s.Secrets = map[string]string{"foo": "old_foo", "bar": "old_bar"}
-				s.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				s.Secrets = map[string]string{fooName: "old_foo", barName: oldBar}
+				s.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return s
 			},
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Secrets = map[string]string{"foo": "new_foo", "bar": "new_bar"}
-				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				a.Secrets = map[string]string{fooName: "new_foo", barName: newBar}
+				a.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return a
 			},
 			wantChanges: true,
@@ -820,12 +820,12 @@ func TestImageDiff(t *testing.T) {
 		{
 			name: "no diff if only ignoreSecretsInDiffCalculation changes",
 			state: func(_ *testing.T, s ImageState) ImageState {
-				s.Secrets = map[string]string{"foo": "bar"}
+				s.Secrets = map[string]string{fooName: barName}
 				return s
 			},
 			inputs: func(_ *testing.T, a ImageArgs) ImageArgs {
-				a.Secrets = map[string]string{"foo": "bar"}
-				a.IgnoreSecretsInDiffCalculation = []string{"foo"}
+				a.Secrets = map[string]string{fooName: barName}
+				a.IgnoreSecretsInDiffCalculation = []string{fooName}
 				return a
 			},
 			wantChanges: false,
@@ -834,13 +834,13 @@ func TestImageDiff(t *testing.T) {
 			name: "diff if local export doesn't exist",
 			state: func(_ *testing.T, state ImageState) ImageState {
 				state.Exports = []Export{
-					{Local: &ExportLocal{Dest: "not-real"}},
+					{Local: &ExportLocal{Dest: notReal}},
 				}
 				return state
 			},
 			inputs: func(_ *testing.T, args ImageArgs) ImageArgs {
 				args.Exports = []Export{
-					{Local: &ExportLocal{Dest: "not-real"}},
+					{Local: &ExportLocal{Dest: notReal}},
 				}
 				return args
 			},
@@ -850,13 +850,13 @@ func TestImageDiff(t *testing.T) {
 			name: "diff if tar export doesn't exist",
 			state: func(_ *testing.T, state ImageState) ImageState {
 				state.Exports = []Export{
-					{Tar: &ExportTar{ExportLocal: ExportLocal{Dest: "not-real"}}},
+					{Tar: &ExportTar{ExportLocal: ExportLocal{Dest: notReal}}},
 				}
 				return state
 			},
 			inputs: func(_ *testing.T, args ImageArgs) ImageArgs {
 				args.Exports = []Export{
-					{Tar: &ExportTar{ExportLocal: ExportLocal{Dest: "not-real"}}},
+					{Tar: &ExportTar{ExportLocal: ExportLocal{Dest: notReal}}},
 				}
 				return args
 			},
@@ -912,19 +912,19 @@ func TestValidateImageArgs(t *testing.T) {
 	t.Run("buildOnPreview", func(t *testing.T) {
 		t.Parallel()
 		args := ImageArgs{
-			Context: &BuildContext{Context: Context{Location: "testdata/noop"}},
+			Context: &BuildContext{Context: Context{Location: testdataNoop}},
 			Tags:    []string{"my-tag"},
 			Exports: []Export{{Registry: &ExportRegistry{ExportImage{Push: pulumi.BoolRef(true)}}}},
 		}
 		actual, err := args.validate(true, true)
 		assert.NoError(t, err)
-		assert.Equal(t, "image", actual.Exports[0].Type)
-		assert.Equal(t, "false", actual.Exports[0].Attrs["push"])
+		assert.Equal(t, exportTypeImage, actual.Exports[0].Type)
+		assert.Equal(t, falseLiteral, actual.Exports[0].Attrs[pushKey])
 
 		actual, err = args.validate(true, false)
 		assert.NoError(t, err)
-		assert.Equal(t, "image", actual.Exports[0].Type)
-		assert.Equal(t, "true", actual.Exports[0].Attrs["push"])
+		assert.Equal(t, exportTypeImage, actual.Exports[0].Type)
+		assert.Equal(t, "true", actual.Exports[0].Attrs[pushKey])
 	})
 
 	t.Run("unknowns", func(t *testing.T) {
@@ -937,8 +937,8 @@ func TestValidateImageArgs(t *testing.T) {
 		// - not allow invalid zero values in non-preview operations.
 		unknowns := ImageArgs{
 			BuildArgs: map[string]string{
-				"known": "value",
-				"":      "",
+				knownKey: "value",
+				"":       "",
 			},
 			Builder:    nil,
 			CacheFrom:  []CacheFrom{{GHA: &CacheFromGitHubActions{}}, {Raw: ""}},
@@ -946,7 +946,7 @@ func TestValidateImageArgs(t *testing.T) {
 			Context:    nil,
 			Exports:    []Export{{Raw: ""}},
 			Dockerfile: nil,
-			Platforms:  []Platform{"linux/amd64", ""},
+			Platforms:  []Platform{platformLinuxAMD64, ""},
 			Registries: []Registry{
 				{
 					Address:  "",
@@ -954,7 +954,7 @@ func TestValidateImageArgs(t *testing.T) {
 					Username: "",
 				},
 			},
-			Tags: []string{"known", ""},
+			Tags: []string{knownKey, ""},
 		}
 
 		_, err := unknowns.validate(true, true)
@@ -968,10 +968,10 @@ func TestValidateImageArgs(t *testing.T) {
 	t.Run("disabled caches", func(t *testing.T) {
 		t.Parallel()
 		args := ImageArgs{
-			Context:   &BuildContext{Context: Context{Location: "testdata/noop"}},
-			CacheFrom: []CacheFrom{{Raw: "type=registry", Disabled: true}},
-			CacheTo:   []CacheTo{{Raw: "type=registry", Disabled: true}},
-			Exports:   []Export{{Raw: "type=registry", Disabled: true}},
+			Context:   &BuildContext{Context: Context{Location: testdataNoop}},
+			CacheFrom: []CacheFrom{{Raw: typeRegistry, Disabled: true}},
+			CacheTo:   []CacheTo{{Raw: typeRegistry, Disabled: true}},
+			Exports:   []Export{{Raw: typeRegistry, Disabled: true}},
 		}
 
 		opts, err := args.validate(true, true)
@@ -998,32 +998,32 @@ func TestValidateImageArgs(t *testing.T) {
 			{
 				name: "gha environment",
 				envs: map[string]string{
-					"ACTIONS_CACHE_URL":        "test-cache-url",
-					"ACTIONS_RUNTIME_TOKEN":    "test-runtime-token",
-					"ACTIONS_RESULTS_URL":      "test-results-url",
+					"ACTIONS_CACHE_URL":        testCacheURL,
+					"ACTIONS_RUNTIME_TOKEN":    testRuntimeToken,
+					"ACTIONS_RESULTS_URL":      testResultsURL,
 					"ACTIONS_CACHE_SERVICE_V2": "true",
 				},
 				args: ImageArgs{
-					Context:   &BuildContext{Context: Context{Location: "testdata/noop"}},
+					Context:   &BuildContext{Context: Context{Location: testdataNoop}},
 					CacheFrom: []CacheFrom{{GHA: &CacheFromGitHubActions{}}},
 					CacheTo: []CacheTo{{GHA: &CacheToGitHubActions{
 						CacheFromGitHubActions: CacheFromGitHubActions{},
 					}}},
 				},
 				wantCacheFrom: &pb.CacheOptionsEntry{
-					Type: "gha",
+					Type: cacheTypeGHA,
 					Attrs: map[string]string{
-						"token":  "test-runtime-token",
-						"url":    "test-cache-url",
-						"url_v2": "test-results-url",
+						"token":  testRuntimeToken,
+						"url":    testCacheURL,
+						"url_v2": testResultsURL,
 					},
 				},
 				wantCacheTo: &pb.CacheOptionsEntry{
-					Type: "gha",
+					Type: cacheTypeGHA,
 					Attrs: map[string]string{
-						"token":  "test-runtime-token",
-						"url":    "test-cache-url",
-						"url_v2": "test-results-url",
+						"token":  testRuntimeToken,
+						"url":    testCacheURL,
+						"url_v2": testResultsURL,
 					},
 				},
 			},
@@ -1034,7 +1034,7 @@ func TestValidateImageArgs(t *testing.T) {
 					"ACTIONS_RUNTIME_TOKEN": "",
 				},
 				args: ImageArgs{
-					Context:   &BuildContext{Context: Context{Location: "testdata/noop"}},
+					Context:   &BuildContext{Context: Context{Location: testdataNoop}},
 					CacheFrom: []CacheFrom{{GHA: &CacheFromGitHubActions{}}},
 					CacheTo: []CacheTo{{GHA: &CacheToGitHubActions{
 						CacheFromGitHubActions: CacheFromGitHubActions{},
@@ -1073,7 +1073,7 @@ func TestValidateImageArgs(t *testing.T) {
 	t.Run("multiple exports pre-0.13", func(t *testing.T) {
 		t.Parallel()
 		args := ImageArgs{
-			Exports: []Export{{Raw: "type=local"}, {Raw: "type=tar"}},
+			Exports: []Export{{Raw: "type=local"}, {Raw: typeTar}},
 		}
 		_, err := args.validate(false, false)
 		assert.ErrorContains(t, err, "multiple exports require a v0.13 buildkit daemon or newer")
@@ -1083,8 +1083,8 @@ func TestValidateImageArgs(t *testing.T) {
 		t.Parallel()
 		args := ImageArgs{
 			Exports:   []Export{{Tar: &ExportTar{}, Local: &ExportLocal{}}},
-			CacheTo:   []CacheTo{{Raw: "type=tar", Local: &CacheToLocal{Dest: "/foo"}}},
-			CacheFrom: []CacheFrom{{Raw: "type=tar", Registry: &CacheFromRegistry{}}},
+			CacheTo:   []CacheTo{{Raw: typeTar, Local: &CacheToLocal{Dest: fooDest}}},
+			CacheFrom: []CacheFrom{{Raw: typeTar, Registry: &CacheFromRegistry{}}},
 		}
 		_, err := args.validate(true, false)
 		assert.ErrorContains(t, err, "exports should only specify one export type")
@@ -1125,7 +1125,7 @@ func TestBuildable(t *testing.T) {
 		{
 			name: "unknown exports",
 			args: ImageArgs{
-				Tags:    []string{"known"},
+				Tags:    []string{knownKey},
 				Exports: []Export{{Raw: ""}},
 			},
 			want: false,
@@ -1133,12 +1133,12 @@ func TestBuildable(t *testing.T) {
 		{
 			name: "unknown registry",
 			args: ImageArgs{
-				Tags:    []string{"known"},
+				Tags:    []string{knownKey},
 				Exports: []Export{{Docker: &ExportDocker{}}},
 				Registries: []Registry{
 					{
-						Address:  "docker.io",
-						Username: "foo",
+						Address:  dockerIO,
+						Username: fooName,
 						Password: "",
 					},
 				},
@@ -1148,14 +1148,14 @@ func TestBuildable(t *testing.T) {
 		{
 			name: "known tags",
 			args: ImageArgs{
-				Tags: []string{"known"},
+				Tags: []string{knownKey},
 			},
 			want: true,
 		},
 		{
 			name: "known exports",
 			args: ImageArgs{
-				Tags:    []string{"known"},
+				Tags:    []string{knownKey},
 				Exports: []Export{{Registry: &ExportRegistry{}}},
 			},
 			want: true,
@@ -1163,13 +1163,13 @@ func TestBuildable(t *testing.T) {
 		{
 			name: "known registry",
 			args: ImageArgs{
-				Tags:    []string{"known"},
+				Tags:    []string{knownKey},
 				Exports: []Export{{Registry: &ExportRegistry{}}},
 				Registries: []Registry{
 					{
-						Address:  "docker.io",
-						Username: "foo",
-						Password: "bar",
+						Address:  dockerIO,
+						Username: fooName,
+						Password: barName,
 					},
 				},
 			},
@@ -1178,9 +1178,9 @@ func TestBuildable(t *testing.T) {
 		{
 			name: "known with ignoreSecretsInDiffCalculation set",
 			args: ImageArgs{
-				Tags:                           []string{"known"},
-				Secrets:                        map[string]string{"foo": "bar"},
-				IgnoreSecretsInDiffCalculation: []string{"foo"},
+				Tags:                           []string{knownKey},
+				Secrets:                        map[string]string{fooName: barName},
+				IgnoreSecretsInDiffCalculation: []string{fooName},
 			},
 			want: true,
 		},
@@ -1199,26 +1199,26 @@ func TestToBuild(t *testing.T) {
 	Max := Max
 
 	ia := ImageArgs{
-		Tags:      []string{"foo", "bar"},
-		Platforms: []Platform{"linux/amd64"},
-		Context:   &BuildContext{Context: Context{Location: "testdata/noop"}},
+		Tags:      []string{fooName, barName},
+		Platforms: []Platform{platformLinuxAMD64},
+		Context:   &BuildContext{Context: Context{Location: testdataNoop}},
 		CacheTo: []CacheTo{
 			{GHA: &CacheToGitHubActions{CacheWithMode: CacheWithMode{&Max}}},
 			{
 				Registry: &CacheToRegistry{
-					CacheFromRegistry: CacheFromRegistry{Ref: "docker.io/foo/bar"},
+					CacheFromRegistry: CacheFromRegistry{Ref: dockerIORef},
 				},
 			},
 			{
 				Registry: &CacheToRegistry{
-					CacheFromRegistry: CacheFromRegistry{Ref: "docker.io/foo/bar:baz"},
+					CacheFromRegistry: CacheFromRegistry{Ref: dockerIOTaggedRef},
 				},
 			},
 		},
 		CacheFrom: []CacheFrom{
-			{S3: &CacheFromS3{Name: "bar"}},
-			{Registry: &CacheFromRegistry{Ref: "docker.io/foo/bar"}},
-			{Registry: &CacheFromRegistry{Ref: "docker.io/foo/bar:baz"}},
+			{S3: &CacheFromS3{Name: barName}},
+			{Registry: &CacheFromRegistry{Ref: dockerIORef}},
+			{Registry: &CacheFromRegistry{Ref: dockerIOTaggedRef}},
 		},
 	}
 

--- a/provider/internal/index.go
+++ b/provider/internal/index.go
@@ -325,10 +325,10 @@ func (i *Index) Diff(
 	replace := provider.PropertyDiff{Kind: provider.UpdateReplace}
 
 	if olds.Tag != news.Tag {
-		diff["tag"] = replace
+		diff[tagKey] = replace
 	}
 	if !reflect.DeepEqual(olds.Sources, news.Sources) {
-		diff["sources"] = update
+		diff[sourcesKey] = update
 	}
 	if olds.Registry != nil && news.Registry != nil {
 		if olds.Registry.Address != news.Registry.Address {
@@ -343,7 +343,7 @@ func (i *Index) Diff(
 	}
 	if (olds.Registry == nil && news.Registry != nil) ||
 		(olds.Registry != nil && news.Registry == nil) {
-		diff["registry"] = update
+		diff[registryLiteral] = update
 	}
 	// Intentionally ignore changes to registry.password
 

--- a/provider/internal/index_test.go
+++ b/provider/internal/index_test.go
@@ -48,14 +48,14 @@ func TestIndexLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"tag": property.New(
+						tagKey: property.New(
 							"docker.io/pulumibot/buildkit-e2e:manifest-unit",
 						),
-						"sources": property.New([]property.Value{
+						sourcesKey: property.New([]property.Value{
 							property.New("docker.io/pulumibot/buildkit-e2e:arm64"),
 							property.New("docker.io/pulumibot/buildkit-e2e:amd64"),
 						}),
-						"push": property.New(false),
+						pushKey: property.New(false),
 					}),
 				}
 			},
@@ -67,18 +67,18 @@ func TestIndexLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"tag": property.New(
+						tagKey: property.New(
 							"docker.io/pulumibot/buildkit-e2e:manifest",
 						),
-						"sources": property.New([]property.Value{
+						sourcesKey: property.New([]property.Value{
 							property.New("docker.io/pulumibot/buildkit-e2e:arm64"),
 							property.New("docker.io/pulumibot/buildkit-e2e:amd64"),
 						}),
-						"push": property.New(true),
-						"registry": property.New(map[string]property.Value{
-							"address":  property.New("docker.io"),
-							"username": property.New("pulumibot"),
-							"password": property.New(os.Getenv("DOCKER_HUB_PASSWORD")).WithSecret(true),
+						pushKey: property.New(true),
+						registryLiteral: property.New(map[string]property.Value{
+							addressKey:  property.New(dockerIO),
+							usernameKey: property.New("pulumibot"),
+							passwordKey: property.New(os.Getenv("DOCKER_HUB_PASSWORD")).WithSecret(true),
 						}),
 					}),
 				}
@@ -97,18 +97,18 @@ func TestIndexLifecycle(t *testing.T) {
 			op: func(_ *testing.T) integration.Operation {
 				return integration.Operation{
 					Inputs: property.NewMap(map[string]property.Value{
-						"tag": property.New(
+						tagKey: property.New(
 							"docker.io/pulumibot/buildkit-e2e:manifest",
 						),
-						"sources": property.New([]property.Value{
+						sourcesKey: property.New([]property.Value{
 							property.New("docker.io/pulumibot/buildkit-e2e:arm64"),
 							property.New("docker.io/pulumibot/buildkit-e2e:amd64"),
 						}),
-						"push": property.New(true),
-						"registry": property.New(map[string]property.Value{
-							"address":  property.New("docker.io"),
-							"username": property.New("pulumibot"),
-							"password": property.New(os.Getenv("DOCKER_HUB_PASSWORD")).WithSecret(true),
+						pushKey: property.New(true),
+						registryLiteral: property.New(map[string]property.Value{
+							addressKey:  property.New(dockerIO),
+							usernameKey: property.New("pulumibot"),
+							passwordKey: property.New(os.Getenv("DOCKER_HUB_PASSWORD")).WithSecret(true),
 						}),
 					}),
 				}
@@ -168,16 +168,16 @@ func TestIndexDiff(t *testing.T) {
 			name: "no diff if registry password changes",
 			state: func(_ *testing.T, s IndexState) IndexState {
 				s.Registry = &Registry{
-					Address:  "foo",
-					Username: "foo",
-					Password: "foo",
+					Address:  fooName,
+					Username: fooName,
+					Password: fooName,
 				}
 				return s
 			},
 			inputs: func(_ *testing.T, a IndexArgs) IndexArgs {
 				a.Registry = &Registry{
-					Address:  "foo",
-					Username: "foo",
+					Address:  fooName,
+					Username: fooName,
 					Password: "DIFFERENT PASSWORD",
 				}
 				return a
@@ -188,7 +188,7 @@ func TestIndexDiff(t *testing.T) {
 			name:  "diff if registry added",
 			state: func(*testing.T, IndexState) IndexState { return baseState },
 			inputs: func(_ *testing.T, a IndexArgs) IndexArgs {
-				a.Registry = &Registry{Address: "foo.com", Username: "foo", Password: "foo"}
+				a.Registry = &Registry{Address: "foo.com", Username: fooName, Password: fooName}
 				return a
 			},
 			wantChanges: true,
@@ -197,17 +197,17 @@ func TestIndexDiff(t *testing.T) {
 			name: "diff if registry user changes",
 			state: func(_ *testing.T, s IndexState) IndexState {
 				s.Registry = &Registry{
-					Address:  "foo",
-					Username: "foo",
-					Password: "foo",
+					Address:  fooName,
+					Username: fooName,
+					Password: fooName,
 				}
 				return s
 			},
 			inputs: func(_ *testing.T, a IndexArgs) IndexArgs {
 				a.Registry = &Registry{
 					Address:  "DIFFERENT USER",
-					Username: "foo",
-					Password: "foo",
+					Username: fooName,
+					Password: fooName,
 				}
 				return a
 			},
@@ -250,7 +250,7 @@ func TestIndexDelete(t *testing.T) {
 		i := &Index{clientF: mockClientF(client)}
 
 		_, err := i.Delete(t.Context(), infer.DeleteRequest[IndexState]{
-			ID: "foo",
+			ID: fooName,
 			State: IndexState{
 				IndexArgs: IndexArgs{Tag: "docker.io/pulumi/test:manifest"},
 				Ref:       "docker.io/pulumi/test:manifest",

--- a/provider/internal/platform.go
+++ b/provider/internal/platform.go
@@ -28,6 +28,9 @@ var _ = (infer.Enum[Platform])((*Platform)(nil))
 // Platform is an enum capturing all available OS/architecture targets.
 type Platform string
 
+// platformLinuxAMD64 is the most commonly referenced platform value.
+const platformLinuxAMD64 = "linux/amd64"
+
 // Values returns all valid Platform values for SDK generation.
 func (Platform) Values() []infer.EnumValue[Platform] {
 	return []infer.EnumValue[Platform]{
@@ -40,7 +43,7 @@ func (Platform) Values() []infer.EnumValue[Platform] {
 		{Value: "freebsd/amd64"},
 		{Value: "freebsd/arm"},
 		{Value: "linux/386"},
-		{Value: "linux/amd64"},
+		{Value: platformLinuxAMD64},
 		{Value: "linux/arm"},
 		{Value: "linux/arm64"},
 		{Value: "linux/mips64"},

--- a/provider/internal/provider.go
+++ b/provider/internal/provider.go
@@ -82,7 +82,7 @@ func NewBuildxProvider(clientF clientF) provider.Provider {
 		infer.Options{
 			Metadata: pschema.Metadata{
 				DisplayName: "docker-build",
-				Keywords:    []string{"docker", "buildkit", "buildx", "kind/native"},
+				Keywords:    []string{"docker", "buildkit", buildxName, "kind/native"},
 				Description: "A Pulumi provider for building modern Docker images with buildx and BuildKit.",
 				Homepage:    "https://pulumi.com",
 				Publisher:   "Pulumi",

--- a/provider/internal/ssh_test.go
+++ b/provider/internal/ssh_test.go
@@ -30,7 +30,7 @@ func TestValidateSSH(t *testing.T) {
 	}{
 		{
 			name:    "invalid path",
-			ssh:     SSH{ID: "foo", Paths: []string{"/not/real"}},
+			ssh:     SSH{ID: fooName, Paths: []string{"/not/real"}},
 			wantErr: "/not/real: no such file or directory",
 		},
 	}


### PR DESCRIPTION
The ci-mgmt workflow update bumps golangci-lint to 2.12.2, which enables stricter `goconst`/`gosec` checks. This hoists repeated string literals into named constants and adds line-scoped `//nolint:gosec` annotations (with reasons) to the fake test-fixture credentials and build-time CLI path arguments. Verified locally with golangci-lint 2.12.2 (uncapped) reporting 0 issues.

Part of #936
Part of pulumi/home#4817
