### PR TITLE
fix(hash): make contextHash reproducible across checkouts, and stop swallowing a Dockerfile read error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- `contextHash` no longer depends on the umask of whoever checked out the build context. Permission bits other than the executable bit are normalised before hashing, so two checkouts of the same commit produce the same hash instead of reporting a `contextHash` change on every preview. (https://github.com/pulumi/pulumi-docker-build/pull/979)
+- A Dockerfile that stats as a local file but cannot be read now returns an error rather than an empty hash and a nil error. (https://github.com/pulumi/pulumi-docker-build/pull/979)
 - `Image` is no longer deleted from state when a registry read fails with a non-404 error (expired credentials, auth failure, or transient network error) during refresh. (https://github.com/pulumi/pulumi-docker-build/pull/930)
 - Fixes a regression where a 404 status code during deletion wasn't considered deleted. (https://github.com/pulumi/pulumi-docker-build/issues/849)
 - Fixed `exec: true` builds failing with `exit status 125` due to malformed buildx arguments. (https://github.com/pulumi/pulumi-docker-build/issues/656)

--- a/provider/internal/context.go
+++ b/provider/internal/context.go
@@ -160,6 +160,20 @@ func (bc *BuildContext) Annotate(a infer.Annotator) {
 	`))
 }
 
+// portableMode reduces a file mode to the parts a build can act on: the file type and the
+// executable bit. The remaining permission bits are not a property of the source -- git records
+// only 100644/100755, so on checkout they come from the umask of whoever materialized the file
+// (umask 022 yields 0644, umask 002 yields 0664). Including them makes contextHash depend on the
+// machine rather than the content, so two checkouts of the same commit disagree forever. See the
+// portability note in hashBuildContext's docs.
+func portableMode(mode gofs.FileMode) gofs.FileMode {
+	perm := gofs.FileMode(0o644)
+	if mode&0o111 != 0 {
+		perm = 0o755
+	}
+	return (mode & ^gofs.ModePerm) | perm
+}
+
 // hashFile hashes a file's contents and accumulates it into the provider Hash.
 func hashFile(
 	h hash.Hash,
@@ -190,7 +204,7 @@ func hashFile(
 	}
 
 	h.Write([]byte(filepath.ToSlash(path.Clean(relativePath))))
-	h.Write([]byte(fileMode.String()))
+	h.Write([]byte(portableMode(fileMode).String()))
 
 	return nil
 }
@@ -217,9 +231,8 @@ func hashBuildContext(
 	}
 
 	if isLocalFile(fs, dockerfilePath) {
-		err := hashDockerfile(h, dockerfilePath)
-		if err != nil {
-			return "", nil
+		if err := hashDockerfile(h, dockerfilePath); err != nil {
+			return "", err
 		}
 	}
 

--- a/provider/internal/context_test.go
+++ b/provider/internal/context_test.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"bufio"
+	gofs "io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -277,6 +278,50 @@ func TestHashFilemodeMatters(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEqual(t, result, baseResult)
+}
+
+func TestHashIgnoresUmaskDerivedPermissions(t *testing.T) {
+	t.Parallel()
+	// git records only 100644/100755, so a checkout's group/other permission bits come from the
+	// umask of whoever materialized the files: umask 022 yields 0644, umask 002 yields 0664. Two
+	// checkouts of the same commit must therefore hash identically, or contextHash reports a
+	// change that no commit can explain and the diff never converges.
+	write := func(t *testing.T, mode gofs.FileMode) string {
+		t.Helper()
+		dir := t.TempDir()
+		dockerfile := filepath.Join(dir, "Dockerfile")
+		require.NoError(t, os.WriteFile(dockerfile, []byte("FROM scratch\nCOPY app.txt /\n"), mode))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "app.txt"), []byte("content"), mode))
+		// os.WriteFile is subject to the process umask, so set the modes explicitly.
+		require.NoError(t, os.Chmod(dockerfile, mode))
+		require.NoError(t, os.Chmod(filepath.Join(dir, "app.txt"), mode))
+		h, err := hashBuildContext(dir, dockerfile, nil)
+		require.NoError(t, err)
+		return h
+	}
+
+	umask022 := write(t, 0o644)
+	umask002 := write(t, 0o664)
+	assert.Equal(t, umask022, umask002,
+		"group-writable checkout must hash the same as a umask-022 checkout")
+}
+
+func TestHashDockerfileErrorIsNotSwallowed(t *testing.T) {
+	t.Parallel()
+	// A Dockerfile that stats as a local file but cannot be read must surface an error. Returning
+	// an empty hash with a nil error makes every subsequent Diff see a changed contextHash.
+	dir := t.TempDir()
+	dockerfile := filepath.Join(dir, "Dockerfile")
+	require.NoError(t, os.WriteFile(dockerfile, []byte("FROM scratch\n"), 0o644))
+	require.NoError(t, os.Chmod(dockerfile, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(dockerfile, 0o644) })
+
+	if _, err := os.ReadFile(dockerfile); err == nil {
+		t.Skip("running as a user that bypasses file permissions")
+	}
+
+	_, err := hashBuildContext(dir, dockerfile, nil)
+	assert.Error(t, err, "an unreadable Dockerfile must not hash to an empty string with nil error")
 }
 
 func TestHashDeepSymlinks(t *testing.T) {


### PR DESCRIPTION
Two independent fixes in `hashBuildContext`, both with tests. Happy to split them if you'd prefer.

## 1. `contextHash` is not reproducible across checkouts

`hashFile` writes `fileMode.String()` into the hash, which includes every permission bit:

```go
h.Write([]byte(filepath.ToSlash(path.Clean(relativePath))))
h.Write([]byte(fileMode.String()))
```

Those bits aren't a property of the source. Git records only `100644`/`100755`, so on checkout the rest come from the umask of whoever materialised the file. Same commit, same index:

```
umask 0022  ->  644
umask 002   ->  664
```

So `contextHash` depends on the machine rather than the content. Two checkouts of the same commit disagree permanently: `Diff` reports `contextHash` changed on every preview, an apply stores the local value, and the next preview elsewhere reports it changed again. It never converges.

### How this showed up

A stack with 11 `Image` resources. Two had contexts in the working tree, checked out months earlier under umask 002. The other nine were fresh clones made under umask 022. **The two reported a change on every single preview, forever**; the nine never did.

Because the task definitions referenced `image.digest`, each phantom image change cascaded into task-definition replacements — 15 pending changes, 13 of them phantom. That made a clean preview impossible, which in turn made a targeted-apply guard unsatisfiable, so shipping an unrelated one-line change required overriding it.

`chmod -R g-w` on two directories removed 11 of the 15 changes. Nothing in `git status` or `jj status` showed anything the entire time, because git doesn't track those bits — which is what made it expensive to find rather than merely annoying.

I reproduced both stored hashes exactly by normalising the modes to 0644 and changing nothing else, which is how I'm confident this is the mechanism and not a coincidence.

### The change

`portableMode` keeps the file type and the executable bit and normalises the remaining permission bits.

This preserves the existing intent rather than reversing it. `TestHashFilemodeMatters` compares `step1` against `step2-chmod-x` — it asserts the **executable** bit matters, and it still passes. The umask-derived bits look like they were swept in by hashing the whole mode string rather than the bits a Dockerfile can observe.

Worth acknowledging the counter-argument: `COPY` does preserve permissions, so a 664 tree genuinely produces a different image than a 644 tree, and hashing them isn't unreasonable. The problem is that the difference is contributed by the builder's environment rather than the commit, so the result is a hash nobody can reproduce and a diff nobody can clear.

**This changes computed hashes, so users get one rebuild on upgrade.** If that's unacceptable in a patch release, the same change behind an opt-in input would still help anyone who asks for it — I'm happy to rework it that way.

### Related

#358 is this symptom, closed with "add a `.dockerignore`". That works when the volatile thing is the *file set*. Here the volatile thing is the *mode*, and one of the two affected contexts already had a `.dockerignore`. #74 (ability to ignore context changes) is the adjacent feature request.

## 2. A Dockerfile read error is swallowed

```go
if isLocalFile(fs, dockerfilePath) {
    err := hashDockerfile(h, dockerfilePath)
    if err != nil {
        return "", nil   // empty hash, nil error
    }
}
```

A Dockerfile that stats as a local file but can't be read yields an empty hash and reports success, which produces the same never-converging diff instead of a failure. Returns the error now.

## Testing

- `TestHashIgnoresUmaskDerivedPermissions` — a 0664 context hashes identically to a 0644 one.
- `TestHashDockerfileErrorIsNotSwallowed` — an unreadable Dockerfile errors instead of returning an empty hash (skips when running as a user that bypasses file permissions).
- Existing hash tests unaffected, `TestHashFilemodeMatters` included.
- `gofmt` and `go vet` clean.
- `TestBuild/sshMount` and `TestBuild/exec-sshMount` fail identically with and without this patch on my machine — no SSH agent socket available. Verified against a stashed tree so I'm not attributing a pre-existing failure to the change.
