### PR TITLE
fix(hash): use each named context's own .dockerignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- Local named build contexts now use their own root `.dockerignore` files when computing `contextHash`. (https://github.com/pulumi/pulumi-docker-build/pull/980)
 - `Image` is no longer deleted from state when a registry read fails with a non-404 error (expired credentials, auth failure, or transient network error) during refresh. (https://github.com/pulumi/pulumi-docker-build/pull/930)
 - Fixes a regression where a 404 status code during deletion wasn't considered deleted. (https://github.com/pulumi/pulumi-docker-build/issues/849)
 - Fixed `exec: true` builds failing with `exit status 125` due to malformed buildx arguments. (https://github.com/pulumi/pulumi-docker-build/issues/656)

--- a/provider/internal/context.go
+++ b/provider/internal/context.go
@@ -240,11 +240,15 @@ func hashBuildContext(
 	for _, key := range keys {
 		namedContext := namedContexts[key]
 		if isLocalDir(fs, namedContext) {
-			fs, err := rootFS(namedContext, excludes)
+			namedExcludes, err := getIgnorePatterns(fs, "", namedContext)
 			if err != nil {
 				return "", err
 			}
-			if _, err := hashPath(h, fs); err != nil {
+			namedFS, err := rootFS(namedContext, namedExcludes)
+			if err != nil {
+				return "", err
+			}
+			if _, err := hashPath(h, namedFS); err != nil {
 				return "", err
 			}
 		}
@@ -301,11 +305,13 @@ func hashDockerfile(h hash.Hash, path string) error {
 // context for the given Dockerfile, if any such patterns exist.
 //
 // Precedence is given to Dockerfile-specific ignore-files as per
-// https://docs.docker.com/build/building/context/#filename-and-location.
+// https://docs.docker.com/build/building/context/#filename-and-location. When
+// dockerfilePath is empty, only the context root's .dockerignore is considered.
 func getIgnorePatterns(fs afero.Fs, dockerfilePath, contextRoot string) ([]string, error) {
-	paths := []string{
+	paths := []string{}
+	if dockerfilePath != "" {
 		// Prefer <Dockerfile>.dockerignore if it's present.
-		dockerfilePath + ".dockerignore",
+		paths = append(paths, dockerfilePath+".dockerignore")
 	}
 
 	if isLocalDir(fs, contextRoot) {

--- a/provider/internal/context_test.go
+++ b/provider/internal/context_test.go
@@ -135,6 +135,68 @@ func TestHashIgnoresFile(t *testing.T) {
 	assert.Equal(t, result, baseResult)
 }
 
+func TestHashNamedContextDoesNotUsePrimaryIgnorePatterns(t *testing.T) {
+	t.Parallel()
+
+	primaryDir := t.TempDir()
+	namedDir := t.TempDir()
+	dockerfile := filepath.Join(primaryDir, _dockerfile)
+	namedFile := filepath.Join(namedDir, "included.txt")
+
+	require.NoError(t, os.WriteFile(dockerfile, nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(primaryDir, ".dockerignore"), []byte("*\n"), 0o600))
+	require.NoError(t, os.WriteFile(namedFile, []byte("before"), 0o600))
+
+	baselineResult, err := hashBuildContext(
+		primaryDir,
+		dockerfile,
+		map[string]string{"named": namedDir},
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(namedFile, []byte("after"), 0o600))
+	modifiedResult, err := hashBuildContext(
+		primaryDir,
+		dockerfile,
+		map[string]string{"named": namedDir},
+	)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, baselineResult, modifiedResult,
+		"primary ignore patterns must not hide changes in a named context")
+}
+
+func TestHashNamedContextUsesItsOwnIgnorePatterns(t *testing.T) {
+	t.Parallel()
+
+	primaryDir := t.TempDir()
+	namedDir := t.TempDir()
+	dockerfile := filepath.Join(primaryDir, _dockerfile)
+	includedFile := filepath.Join(namedDir, "included.txt")
+	ignoredFile := filepath.Join(namedDir, "ignored.txt")
+	namedContexts := map[string]string{"named": namedDir}
+
+	require.NoError(t, os.WriteFile(dockerfile, nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(namedDir, ".dockerignore"), []byte("ignored.txt\n"), 0o600))
+	require.NoError(t, os.WriteFile(includedFile, []byte("included-before"), 0o600))
+	require.NoError(t, os.WriteFile(ignoredFile, []byte("ignored-before"), 0o600))
+
+	baselineResult, err := hashBuildContext(primaryDir, dockerfile, namedContexts)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(ignoredFile, []byte("ignored-after"), 0o600))
+	ignoredResult, err := hashBuildContext(primaryDir, dockerfile, namedContexts)
+	require.NoError(t, err)
+	assert.Equal(t, baselineResult, ignoredResult,
+		"changes ignored by the named context must not affect the hash")
+
+	require.NoError(t, os.WriteFile(includedFile, []byte("included-after"), 0o600))
+	includedResult, err := hashBuildContext(primaryDir, dockerfile, namedContexts)
+	require.NoError(t, err)
+	assert.NotEqual(t, baselineResult, includedResult,
+		"changes included by the named context must affect the hash")
+}
+
 // Tests that we handle .dockerignore exclusions such as "!foo/*/bar".
 //
 // See:
@@ -341,6 +403,15 @@ func TestDockerIgnore(t *testing.T) {
 				dockerignoreName: rootIgnore,
 			},
 			want: []string{rootIgnore},
+		},
+		{
+			name:    "context without Dockerfile uses its root dockerignore",
+			context: "named",
+			fs: map[string]string{
+				dockerignoreName:            rootIgnore,
+				"named/" + dockerignoreName: customIgnore,
+			},
+			want: []string{customIgnore},
 		},
 		{
 			name:       "Dockerfile with root dockerignore and custom dockerignore",


### PR DESCRIPTION
`hashBuildContext` currently reads the primary build context's ignore rules once and reuses them when hashing every local named context.

That differs from the actual build behavior. BuildKit treats each local named context as its own build context and applies that context's root `.dockerignore`.

This can cause source files consumed by a build to be absent from `contextHash`. For example:

- The primary context's `.dockerignore` contains `*`.
- A local named context contains `source.txt` and does not ignore it.
- The Dockerfile consumes that named context with `COPY --from=<name>`.
- Editing `source.txt` does not change the current provider hash because the primary context's `*` rule is incorrectly applied to the named context.

Pulumi can therefore consider the image unchanged and skip rebuilding it, leaving the previous image in use until some other build input changes.

## Change

Each local named context now loads and applies its own root `.dockerignore` when contributing to `contextHash`.

Passing an empty Dockerfile path to `getIgnorePatterns` means only the named context's own root `.dockerignore` is used; no Dockerfile-specific ignore file is consulted. Primary-context and remote named-context behavior remain unchanged.

BuildKit already applies these per-context ignore rules during the actual build. This change makes Pulumi's change-detection hash use the same inputs that BuildKit consumes.

## Testing

Added regression coverage proving that:

- A primary context's `*` rule no longer hides changes in a local named context.
- Changes ignored by a named context's own `.dockerignore` leave the hash unchanged.
- Changes included by the named context change the hash.
- Calling `getIgnorePatterns` without a Dockerfile uses the specified context root's `.dockerignore`, rather than a `.dockerignore` from the working directory.

Affected images may rebuild once after upgrading because the corrected `contextHash` can differ from the previously stored value. This does not change the image's build semantics; it corrects change detection to match the inputs BuildKit already uses.

## Related

#979 contains separate fixes for `contextHash` reproducibility and Dockerfile error handling. This PR addresses local named-context ignore handling.
